### PR TITLE
feat: add structured file logging with electron-log

### DIFF
--- a/dashboard/electron/config-manager.js
+++ b/dashboard/electron/config-manager.js
@@ -9,6 +9,7 @@ const path = require('path');
 const os = require('os');
 const fs = require('fs');
 const { app } = require('electron');
+const log = require('./logger');
 
 // App constants
 const APP_NAME = 'googol-vibe';
@@ -32,7 +33,7 @@ class ConfigManager {
         this.config = this._loadConfig();
         this._initialized = true;
 
-        console.log(`[ConfigManager] Initialized: ${this.configDir}`);
+        log.info(`[ConfigManager] Initialized: ${this.configDir}`);
     }
 
     /**
@@ -83,7 +84,7 @@ class ConfigManager {
             try {
                 return JSON.parse(fs.readFileSync(configPath, 'utf8'));
             } catch (e) {
-                console.error('[ConfigManager] Error loading config:', e);
+                log.error('[ConfigManager] Error loading config:', e);
             }
         }
 
@@ -137,7 +138,7 @@ class ConfigManager {
         // Legacy location (backwards compatibility)
         const legacyPath = this._findLegacyCredentials();
         if (legacyPath) {
-            console.log(`[ConfigManager] Using legacy credentials: ${legacyPath}`);
+            log.info(`[ConfigManager] Using legacy credentials: ${legacyPath}`);
             return legacyPath;
         }
 
@@ -274,7 +275,7 @@ class ConfigManager {
         const destPath = path.join(this.configDir, 'credentials.json');
         await fs.promises.writeFile(destPath, content);
 
-        console.log(`[ConfigManager] Credentials imported to: ${destPath}`);
+        log.info(`[ConfigManager] Credentials imported to: ${destPath}`);
         return destPath;
     }
 
@@ -294,7 +295,7 @@ class ConfigManager {
         if (fs.existsSync(legacyTokenPath)) {
             const content = await fs.promises.readFile(legacyTokenPath);
             await fs.promises.writeFile(newTokenPath, content);
-            console.log(`[ConfigManager] Token migrated to: ${newTokenPath}`);
+            log.info(`[ConfigManager] Token migrated to: ${newTokenPath}`);
             return true;
         }
 

--- a/dashboard/electron/logger.js
+++ b/dashboard/electron/logger.js
@@ -1,0 +1,15 @@
+const log = require('electron-log/main');
+
+log.initialize();
+
+// File transport: 5MB max, 5 files retained
+log.transports.file.maxSize = 5 * 1024 * 1024;
+log.transports.file.maxFiles = 5;
+log.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}';
+
+// Level: debug in development, info in production
+const level = process.env.NODE_ENV === 'development' ? 'debug' : 'info';
+log.transports.file.level = level;
+log.transports.console.level = level;
+
+module.exports = log;

--- a/dashboard/electron/main.js
+++ b/dashboard/electron/main.js
@@ -9,6 +9,9 @@ const telemetry = require('./telemetry');
 const recurrenceManager = require('./recurrence-manager');
 const notificationManager = require('./notification-manager');
 const syncController = require('./sync-controller');
+const log = require('./logger');
+
+log.info('[Googol Vibe] App starting — log transport active');
 
 // Handle EPIPE errors gracefully - occurs when stdout/stderr pipe closes
 process.stdout?.on?.('error', (err) => {
@@ -87,7 +90,7 @@ async function loadCredentials() {
         const keys = JSON.parse(content);
         return keys.installed || keys.web;
     } catch (e) {
-        console.error("Error loading credentials from:", configManager.getCredentialsPath(), e);
+        log.error("Error loading credentials from:", configManager.getCredentialsPath(), e);
         return null; // Handle missing credentials gracefully
     }
 }
@@ -186,7 +189,7 @@ async function loadSavedCredentialsIfExist() {
         client.setCredentials(tokens);
         return client;
     } catch (err) {
-        console.error('Error loading saved credentials:', err);
+        log.error('Error loading saved credentials:', err);
         return null;
     }
 }
@@ -195,7 +198,7 @@ async function saveCredentials(client) {
     const tokenPath = configManager.getTokenPath();
     const payload = JSON.stringify(client.credentials);
     await fs.promises.writeFile(tokenPath, payload);
-    console.log('Token saved to:', tokenPath);
+    log.info('Token saved to:', tokenPath);
 }
 
 // ========================================
@@ -208,17 +211,17 @@ async function checkAndGenerateRecurringTasks() {
     try {
         if (!authClient) authClient = await loadSavedCredentialsIfExist();
         if (!authClient) {
-            console.log('[Recurrence] No auth client, skipping check');
+            log.info('[Recurrence] No auth client, skipping check');
             return;
         }
 
         const dueRules = recurrenceManager.getDueRules();
         if (dueRules.length === 0) {
-            console.log('[Recurrence] No tasks due');
+            log.info('[Recurrence] No tasks due');
             return;
         }
 
-        console.log(`[Recurrence] ${dueRules.length} task(s) due for generation`);
+        log.info(`[Recurrence] ${dueRules.length} task(s) due for generation`);
         const tasks = google.tasks({ version: 'v1', auth: authClient });
 
         for (const rule of dueRules) {
@@ -233,7 +236,7 @@ async function checkAndGenerateRecurringTasks() {
                     }
                 });
 
-                console.log(`[Recurrence] Generated task: ${rule.title}`);
+                log.info(`[Recurrence] Generated task: ${rule.title}`);
 
                 // Mark as generated and calculate next occurrence
                 recurrenceManager.markGenerated(rule.id);
@@ -250,11 +253,11 @@ async function checkAndGenerateRecurringTasks() {
                     });
                 }
             } catch (e) {
-                console.error(`[Recurrence] Failed to generate task "${rule.title}":`, e.message);
+                log.error(`[Recurrence] Failed to generate task "${rule.title}":`, e.message);
             }
         }
     } catch (e) {
-        console.error('[Recurrence] Scheduler error:', e);
+        log.error('[Recurrence] Scheduler error:', e);
     }
 }
 
@@ -267,7 +270,7 @@ function startRecurrenceScheduler() {
         checkAndGenerateRecurringTasks();
     }, 60 * 60 * 1000);
 
-    console.log('[Recurrence] Scheduler started (hourly checks)');
+    log.info('[Recurrence] Scheduler started (hourly checks)');
 }
 
 function stopRecurrenceScheduler() {
@@ -288,9 +291,9 @@ async function startSyncController() {
     if (authClient) {
         syncController.init(authClient, mainWindow);
         syncController.start();
-        console.log('[SyncController] Started background sync');
+        log.info('[SyncController] Started background sync');
     } else {
-        console.log('[SyncController] No auth client, will start after login');
+        log.info('[SyncController] No auth client, will start after login');
     }
 }
 
@@ -364,7 +367,7 @@ const createWindow = () => {
     // Security: Block navigation to untrusted domains
     mainWindow.webContents.on('will-navigate', (event, navigationUrl) => {
         if (!isTrustedURL(navigationUrl)) {
-            console.warn('[Security] Blocked navigation to:', navigationUrl);
+            log.warn('[Security] Blocked navigation to:', navigationUrl);
             event.preventDefault();
         }
     });
@@ -375,7 +378,7 @@ const createWindow = () => {
             // Open Google links in system browser
             shell.openExternal(url);
         } else {
-            console.warn('[Security] Blocked window open to:', url);
+            log.warn('[Security] Blocked window open to:', url);
         }
         return { action: 'deny' };
     });
@@ -384,16 +387,16 @@ const createWindow = () => {
 app.on('ready', () => {
     // Initialize configuration manager
     configManager.init();
-    console.log('[Googol Vibe] Config paths:', configManager.debugPaths());
+    log.info('[Googol Vibe] Config paths:', configManager.debugPaths());
 
     // Initialize recurrence manager
     recurrenceManager.init();
-    console.log('[Googol Vibe] Recurrence manager initialized');
+    log.info('[Googol Vibe] Recurrence manager initialized');
 
     // Initialize notification manager with saved settings
     const notificationSettings = configManager.getNotificationSettings();
     notificationManager.init(notificationSettings);
-    console.log('[Googol Vibe] Notification manager initialized');
+    log.info('[Googol Vibe] Notification manager initialized');
 
     // Initialize telemetry (opt-in only)
     telemetry.initTelemetry();
@@ -500,7 +503,7 @@ app.on('ready', () => {
 
             return { success: true };
         } catch (error) {
-            console.error('Login failed', error);
+            log.error('Login failed', error);
             return { success: false, error: error.message };
         }
     });
@@ -514,7 +517,7 @@ app.on('ready', () => {
             const res = await service.userinfo.get();
             return res.data;
         } catch (e) {
-            console.error("Profile fetch error", e);
+            log.error("Profile fetch error", e);
             throw e;
         }
     });
@@ -551,12 +554,12 @@ app.on('ready', () => {
                         unread: isUnread
                     });
                 } catch (e) {
-                    console.error('Error fetching email details', e);
+                    log.error('Error fetching email details', e);
                 }
             }));
             return emailList;
         } catch (e) {
-            console.error("Gmail fetch error", e);
+            log.error("Gmail fetch error", e);
             return []; // Return empty array instead of crashing
         }
     });
@@ -583,7 +586,7 @@ app.on('ready', () => {
                 htmlLink: event.htmlLink
             }));
         } catch (e) {
-            console.error("Calendar fetch error", e);
+            log.error("Calendar fetch error", e);
             return [];
         }
     });
@@ -602,7 +605,7 @@ app.on('ready', () => {
             });
             return res.data.files;
         } catch (e) {
-            console.error("Drive fetch error", e);
+            log.error("Drive fetch error", e);
             return [];
         }
     });
@@ -622,7 +625,7 @@ app.on('ready', () => {
             });
             return res.data.files;
         } catch (e) {
-            console.error("Documents fetch error", e);
+            log.error("Documents fetch error", e);
             return [];
         }
     });
@@ -658,7 +661,7 @@ app.on('ready', () => {
                     attendees: event.attendees?.length || 0
                 }));
         } catch (e) {
-            console.error("Meetings fetch error", e);
+            log.error("Meetings fetch error", e);
             return [];
         }
     });
@@ -691,7 +694,7 @@ app.on('ready', () => {
                 }))
             };
         } catch (e) {
-            console.error("Tasks fetch error", e);
+            log.error("Tasks fetch error", e);
             return { taskListId: null, tasks: [] };
         }
     });
@@ -709,7 +712,7 @@ app.on('ready', () => {
             });
             return res.data;
         } catch (e) {
-            console.error("Create task error", e);
+            log.error("Create task error", e);
             throw e;
         }
     });
@@ -728,7 +731,7 @@ app.on('ready', () => {
             });
             return { success: true };
         } catch (e) {
-            console.error("Complete task error", e);
+            log.error("Complete task error", e);
             throw e;
         }
     });
@@ -747,7 +750,7 @@ app.on('ready', () => {
             });
             return res.data;
         } catch (e) {
-            console.error("Update task error", e);
+            log.error("Update task error", e);
             throw e;
         }
     });
@@ -762,7 +765,7 @@ app.on('ready', () => {
             await tasks.tasks.delete({ tasklist: taskListId, task: taskId });
             return { success: true };
         } catch (e) {
-            console.error("Delete task error", e);
+            log.error("Delete task error", e);
             throw e;
         }
     });
@@ -908,7 +911,7 @@ app.on('ready', () => {
 
         // Security: Validate docId contains only safe characters (alphanumeric, hyphens, underscores)
         if (!docId || !/^[a-zA-Z0-9_-]+$/.test(docId)) {
-            console.warn('[Security] Blocked switch-to-edit with invalid docId:', docId);
+            log.warn('[Security] Blocked switch-to-edit with invalid docId:', docId);
             return;
         }
 
@@ -928,7 +931,7 @@ app.on('ready', () => {
         // Security: Only allow trusted Google domains in the BrowserView
         // The BrowserView shares the persist:googleos session (Google auth cookies)
         if (!isTrustedURL(url)) {
-            console.warn('[Security] Blocked view-content for untrusted URL:', url);
+            log.warn('[Security] Blocked view-content for untrusted URL:', url);
             return;
         }
 
@@ -1057,7 +1060,7 @@ app.on('ready', () => {
                 return "I can help you check your **emails**, **schedule**, **files**, or **tasks**. Try asking 'What meetings do I have?' or 'Show my tasks'.";
             }
         } catch (e) {
-            console.error("Agent Error", e);
+            log.error("Agent Error", e);
             throw new Error("Sorry, I encountered an error talking to Google services: " + e.message);
         }
     });
@@ -1075,7 +1078,7 @@ app.on('ready', () => {
                 await fs.promises.unlink(legacyPath);
             }
         } catch (e) {
-            console.error("Error removing token:", e);
+            log.error("Error removing token:", e);
         }
 
         try {
@@ -1088,7 +1091,7 @@ app.on('ready', () => {
             const authSession = require('electron').session.fromPartition('persist:googleos');
             await authSession.clearStorageData();
         } catch (e) {
-            console.error("Error clearing session", e);
+            log.error("Error clearing session", e);
         }
 
         // Reset onboarding state

--- a/dashboard/electron/notification-manager.js
+++ b/dashboard/electron/notification-manager.js
@@ -5,6 +5,7 @@
 
 const { Notification, nativeImage, app } = require('electron');
 const path = require('path');
+const log = require('./logger');
 
 /**
  * Safe logging wrapper - prevents EPIPE crashes when stdout is closed
@@ -12,7 +13,7 @@ const path = require('path');
 function safeLog(...args) {
     try {
         if (process.stdout && process.stdout.writable) {
-            console.log(...args);
+            log.info(...args);
         }
     } catch (err) {
         // Silently ignore EPIPE errors - stdout/stderr pipe closed

--- a/dashboard/electron/recurrence-manager.js
+++ b/dashboard/electron/recurrence-manager.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 const path = require('path');
 const { RRule } = require('rrule');
 const configManager = require('./config-manager');
+const log = require('./logger');
 
 class RecurrenceManager {
     constructor() {
@@ -36,7 +37,7 @@ class RecurrenceManager {
                 this.rules = [];
             }
         } catch (e) {
-            console.error('[RecurrenceManager] Failed to load rules:', e);
+            log.error('[RecurrenceManager] Failed to load rules:', e);
             this.rules = [];
         }
     }
@@ -49,7 +50,7 @@ class RecurrenceManager {
             const data = { rules: this.rules, updatedAt: new Date().toISOString() };
             fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
         } catch (e) {
-            console.error('[RecurrenceManager] Failed to save rules:', e);
+            log.error('[RecurrenceManager] Failed to save rules:', e);
         }
     }
 
@@ -160,7 +161,7 @@ class RecurrenceManager {
             const next = rule.after(after, true); // inclusive
             return next ? next.toISOString() : null;
         } catch (e) {
-            console.error('[RecurrenceManager] Invalid RRULE:', rruleString, e);
+            log.error('[RecurrenceManager] Invalid RRULE:', rruleString, e);
             return null;
         }
     }

--- a/dashboard/electron/sync-controller.js
+++ b/dashboard/electron/sync-controller.js
@@ -11,6 +11,7 @@
 
 const { google } = require('googleapis');
 const notificationManager = require('./notification-manager');
+const logger = require('./logger');
 
 // Sync intervals (ms) - Aggressive polling for real-time feel
 const SYNC_INTERVALS = {
@@ -29,7 +30,7 @@ const INITIAL_DELAY = 3 * 1000; // 3 seconds after app ready
 function log(...args) {
     try {
         if (process.stdout?.writable) {
-            console.log('[SyncController]', ...args);
+            logger.info('[SyncController]', ...args);
         }
     } catch {
         // Silently ignore EPIPE

--- a/dashboard/electron/telemetry.js
+++ b/dashboard/electron/telemetry.js
@@ -9,6 +9,7 @@
  */
 
 const configManager = require('./config-manager');
+const log = require('./logger');
 
 // Sentry DSN - replace with your actual DSN when ready
 // For now, use empty string to prevent any data transmission
@@ -26,12 +27,12 @@ function initTelemetry() {
     // 2. DSN is configured
     // 3. Not already initialized
     if (!configManager.isTelemetryEnabled()) {
-        console.log('[Telemetry] Disabled - user has not opted in');
+        log.info('[Telemetry] Disabled - user has not opted in');
         return false;
     }
 
     if (!SENTRY_DSN) {
-        console.log('[Telemetry] DSN not configured - skipping initialization');
+        log.info('[Telemetry] DSN not configured - skipping initialization');
         return false;
     }
 
@@ -98,10 +99,10 @@ function initTelemetry() {
         });
 
         sentryInitialized = true;
-        console.log('[Telemetry] Sentry initialized (opt-in)');
+        log.info('[Telemetry] Sentry initialized (opt-in)');
         return true;
     } catch (e) {
-        console.error('[Telemetry] Failed to initialize Sentry:', e.message);
+        log.error('[Telemetry] Failed to initialize Sentry:', e.message);
         return false;
     }
 }
@@ -119,7 +120,7 @@ function enableTelemetry() {
  */
 function disableTelemetry() {
     configManager.setTelemetryEnabled(false);
-    console.log('[Telemetry] Disabled - will take effect on next app start');
+    log.info('[Telemetry] Disabled - will take effect on next app start');
     return true;
 }
 

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@google-cloud/local-auth": "^3.0.1",
                 "@sentry/electron": "^5.0.0",
+                "electron-log": "^5.4.3",
                 "electron-store": "^10.0.0",
                 "framer-motion": "^11.15.0",
                 "googleapis": "^169.0.0",
@@ -5562,6 +5563,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/electron-log": {
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz",
+            "integrity": "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/electron-publish": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -31,6 +31,7 @@
     "dependencies": {
         "@google-cloud/local-auth": "^3.0.1",
         "@sentry/electron": "^5.0.0",
+        "electron-log": "^5.4.3",
         "electron-store": "^10.0.0",
         "framer-motion": "^11.15.0",
         "googleapis": "^169.0.0",


### PR DESCRIPTION
## Summary

- Replaces all bare `console.log/warn/error` calls across the `electron/` directory with `electron-log`, giving the app persistent file logging in production
- Adds `dashboard/electron/logger.js` as the single configuration point: 5 MB rotation, 5 files retained, `[YYYY-MM-DD HH:mm:ss.ms] [level] text` format, `debug` level in development and `info` in production
- Log file written to `%APPDATA%\googol-vibe\logs\main.log` (Windows) / `~/Library/Logs/googol-vibe/main.log` (macOS) automatically via `app.getPath('logs')`

## Test plan

- [x] `rg "console\." dashboard/electron/ --type js` returns no results (excluding logger.js)
- [x] Log file exists at `%APPDATA%\googol-vibe\logs\main.log` after launching the app
- [x] Log file contains `[Googol Vibe] App starting — log transport active` as first entry
- [x] `[info]`, `[warn]`, and `[error]` levels all appear correctly in the log file
- [x] `logger.js` sets `maxSize = 5MB`, `maxFiles = 5`, and level switches correctly between dev/prod
- [x] EPIPE wrapper functions (`log()` in sync-controller.js, `safeLog()` in notification-manager.js) still intact

Closes #8