### PR TITLE
test: P1 test coverage for electron modules

### DIFF
--- a/dashboard/electron/__tests__/config-manager.test.mjs
+++ b/dashboard/electron/__tests__/config-manager.test.mjs
@@ -127,7 +127,8 @@ describe('ConfigManager', () => {
 
     it('uses token dir env var when set', () => {
       process.env.GOOGLE_TOKEN_DIR = '/custom/tokens'
-      expect(configManager.getTokenPath()).toBe('/custom/tokens/token_electron.json')
+      const expected = path.join('/custom/tokens', 'token_electron.json')
+      expect(configManager.getTokenPath()).toBe(expected)
     })
   })
 

--- a/dashboard/electron/__tests__/notification-manager.test.mjs
+++ b/dashboard/electron/__tests__/notification-manager.test.mjs
@@ -1,0 +1,533 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRequire } from 'module'
+import { electronMock, mockNotification } from './setup.mjs'
+
+const require = createRequire(import.meta.url)
+
+let notificationManager
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockNotification.isSupported.mockReturnValue(true)
+
+  // Clear module cache to get a fresh instance each test
+  const resolved = require.resolve('../notification-manager.js')
+  delete require.cache[resolved]
+  notificationManager = require('../notification-manager.js')
+})
+
+afterEach(() => {
+  notificationManager.cancelAll()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+/* ================================================================== */
+/*  init                                                               */
+/* ================================================================== */
+
+describe('init', () => {
+  it('initialises with default settings', () => {
+    notificationManager.init()
+    const settings = notificationManager.getSettings()
+    expect(settings.enabled).toBe(true)
+    expect(settings.taskReminders).toBe(true)
+    expect(settings.calendarReminders).toBe(true)
+    expect(settings.emailNotifications).toBe(true)
+  })
+
+  it('merges saved settings on init', () => {
+    notificationManager.init({ quietHoursEnabled: true, quietHoursStart: 23 })
+    const settings = notificationManager.getSettings()
+    expect(settings.quietHoursEnabled).toBe(true)
+    expect(settings.quietHoursStart).toBe(23)
+    // other defaults preserved
+    expect(settings.enabled).toBe(true)
+  })
+
+  it('logs unsupported when Notification.isSupported returns false', () => {
+    mockNotification.isSupported.mockReturnValue(false)
+    notificationManager.init()
+    // should not throw
+  })
+})
+
+/* ================================================================== */
+/*  show                                                               */
+/* ================================================================== */
+
+describe('show', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('creates and shows a notification', () => {
+    const result = notificationManager.show({
+      title: 'Test',
+      body: 'Hello',
+    })
+    expect(result).not.toBeNull()
+    expect(result.show).toHaveBeenCalled()
+    expect(result.title).toBe('Test')
+  })
+
+  it('returns null when notifications are disabled', () => {
+    notificationManager.updateSettings({ enabled: false })
+    const result = notificationManager.show({ title: 'X', body: 'Y' })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when platform unsupported', () => {
+    mockNotification.isSupported.mockReturnValue(false)
+    const result = notificationManager.show({ title: 'X', body: 'Y' })
+    expect(result).toBeNull()
+  })
+
+  it('returns null for disabled task category', () => {
+    notificationManager.updateSettings({ taskReminders: false })
+    const result = notificationManager.show({
+      title: 'Task',
+      body: 'Due',
+      category: 'task',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null for disabled calendar category', () => {
+    notificationManager.updateSettings({ calendarReminders: false })
+    const result = notificationManager.show({
+      title: 'Event',
+      body: 'Soon',
+      category: 'calendar',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null for disabled email category', () => {
+    notificationManager.updateSettings({ emailNotifications: false })
+    const result = notificationManager.show({
+      title: 'Email',
+      body: 'New',
+      category: 'email',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null for disabled recurring category', () => {
+    notificationManager.updateSettings({ recurringTaskAlerts: false })
+    const result = notificationManager.show({
+      title: 'Recurring',
+      body: 'Created',
+      category: 'recurring',
+    })
+    expect(result).toBeNull()
+  })
+
+  it('attaches custom data to the notification', () => {
+    const result = notificationManager.show({
+      title: 'T',
+      body: 'B',
+      data: { type: 'task', taskId: '123' },
+    })
+    expect(result._customData).toEqual({ type: 'task', taskId: '123' })
+  })
+
+  it('registers click handler', () => {
+    const onClick = vi.fn()
+    const result = notificationManager.show({
+      title: 'T',
+      body: 'B',
+      onClick,
+    })
+    expect(result.on).toHaveBeenCalledWith('click', expect.any(Function))
+  })
+
+  it('registers close handler', () => {
+    const result = notificationManager.show({ title: 'T', body: 'B' })
+    expect(result.on).toHaveBeenCalledWith('close', expect.any(Function))
+  })
+})
+
+/* ================================================================== */
+/*  Quiet hours                                                        */
+/* ================================================================== */
+
+describe('quiet hours', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('suppresses notifications during overnight quiet hours', () => {
+    notificationManager.updateSettings({
+      quietHoursEnabled: true,
+      quietHoursStart: 22,
+      quietHoursEnd: 8,
+    })
+    // Set time to 23:00
+    vi.setSystemTime(new Date(2026, 0, 15, 23, 0, 0))
+    const result = notificationManager.show({ title: 'Late', body: 'Night' })
+    expect(result).toBeNull()
+  })
+
+  it('allows notifications outside quiet hours', () => {
+    notificationManager.updateSettings({
+      quietHoursEnabled: true,
+      quietHoursStart: 22,
+      quietHoursEnd: 8,
+    })
+    // Set time to 12:00
+    vi.setSystemTime(new Date(2026, 0, 15, 12, 0, 0))
+    const result = notificationManager.show({ title: 'Noon', body: 'Alert' })
+    expect(result).not.toBeNull()
+  })
+
+  it('handles daytime quiet hours (start < end)', () => {
+    notificationManager.updateSettings({
+      quietHoursEnabled: true,
+      quietHoursStart: 9,
+      quietHoursEnd: 17,
+    })
+    vi.setSystemTime(new Date(2026, 0, 15, 10, 0, 0))
+    const result = notificationManager.show({ title: 'Work', body: 'Hours' })
+    expect(result).toBeNull()
+  })
+
+  it('allows notifications when quiet hours are disabled', () => {
+    notificationManager.updateSettings({ quietHoursEnabled: false })
+    vi.setSystemTime(new Date(2026, 0, 15, 23, 0, 0))
+    const result = notificationManager.show({ title: 'Late', body: 'OK' })
+    expect(result).not.toBeNull()
+  })
+})
+
+/* ================================================================== */
+/*  Convenience show* methods                                          */
+/* ================================================================== */
+
+describe('showTaskReminder', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('shows a task reminder notification', () => {
+    const result = notificationManager.showTaskReminder({
+      id: 't1',
+      title: 'Buy milk',
+      due: '2026-03-15T10:00:00Z',
+    })
+    expect(result).not.toBeNull()
+    expect(result.title).toBe('Task Reminder')
+    expect(result.body).toBe('Buy milk')
+  })
+
+  it('handles task without due date', () => {
+    const result = notificationManager.showTaskReminder({
+      id: 't2',
+      title: 'Undated task',
+    })
+    expect(result).not.toBeNull()
+  })
+})
+
+describe('showCalendarReminder', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('shows a calendar event reminder', () => {
+    const result = notificationManager.showCalendarReminder({
+      id: 'e1',
+      summary: 'Standup',
+      start: '2026-03-15T09:00:00Z',
+    })
+    expect(result).not.toBeNull()
+    expect(result.title).toBe('Standup')
+  })
+
+  it('defaults title when summary is missing', () => {
+    const result = notificationManager.showCalendarReminder({
+      id: 'e2',
+      start: '2026-03-15T09:00:00Z',
+    })
+    expect(result.title).toBe('Calendar Event')
+  })
+})
+
+describe('showMeetingReminder', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('shows a meeting reminder', () => {
+    const result = notificationManager.showMeetingReminder({
+      id: 'm1',
+      summary: 'Sprint Review',
+      start: '2026-03-15T14:00:00Z',
+      meetLink: 'https://meet.google.com/abc',
+    })
+    expect(result).not.toBeNull()
+    expect(result.title).toBe('Meeting Starting Soon')
+  })
+})
+
+describe('showEmailNotification', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('shows email notification with sender name', () => {
+    const result = notificationManager.showEmailNotification({
+      id: 'em1',
+      from: 'Alice <alice@example.com>',
+      subject: 'Hello',
+    })
+    expect(result).not.toBeNull()
+    expect(result.title).toBe('Alice')
+  })
+
+  it('falls back to "New Email" when from is empty', () => {
+    const result = notificationManager.showEmailNotification({
+      id: 'em2',
+      subject: 'No sender',
+    })
+    expect(result.title).toBe('New Email')
+  })
+})
+
+describe('showRecurringTaskGenerated', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('shows recurring task notification', () => {
+    const result = notificationManager.showRecurringTaskGenerated(
+      { id: 'r1', title: 'Weekly review' },
+      'task-99'
+    )
+    expect(result).not.toBeNull()
+    expect(result.title).toBe('Recurring Task Created')
+    expect(result.body).toBe('Weekly review')
+  })
+})
+
+/* ================================================================== */
+/*  Scheduling                                                         */
+/* ================================================================== */
+
+describe('schedule', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('schedules a notification for a future time', () => {
+    vi.setSystemTime(new Date('2026-03-15T10:00:00Z'))
+    const future = new Date('2026-03-15T10:05:00Z') // 5 min from now
+    notificationManager.schedule('s1', future, {
+      title: 'Scheduled',
+      body: 'Test',
+    })
+    const scheduled = notificationManager.getScheduled()
+    expect(scheduled).toHaveLength(1)
+    expect(scheduled[0].id).toBe('s1')
+  })
+
+  it('skips scheduling when time is in the past', () => {
+    vi.setSystemTime(new Date('2026-03-15T10:00:00Z'))
+    const past = new Date('2026-03-15T09:00:00Z')
+    notificationManager.schedule('s2', past, {
+      title: 'Past',
+      body: 'Skip',
+    })
+    expect(notificationManager.getScheduled()).toHaveLength(0)
+  })
+
+  it('fires the notification when timeout elapses', () => {
+    vi.setSystemTime(new Date('2026-03-15T10:00:00Z'))
+    const future = new Date('2026-03-15T10:01:00Z') // 1 min
+    notificationManager.schedule('s3', future, {
+      title: 'Fire',
+      body: 'Now',
+    })
+    expect(notificationManager.getScheduled()).toHaveLength(1)
+
+    vi.advanceTimersByTime(60 * 1000) // advance 1 min
+    // After firing, the entry is removed from scheduled
+    expect(notificationManager.getScheduled()).toHaveLength(0)
+  })
+
+  it('replaces an existing scheduled notification with the same id', () => {
+    vi.setSystemTime(new Date('2026-03-15T10:00:00Z'))
+    const t1 = new Date('2026-03-15T10:05:00Z')
+    const t2 = new Date('2026-03-15T10:10:00Z')
+    notificationManager.schedule('dup', t1, { title: 'First', body: '1' })
+    notificationManager.schedule('dup', t2, { title: 'Second', body: '2' })
+    const scheduled = notificationManager.getScheduled()
+    expect(scheduled).toHaveLength(1)
+    expect(scheduled[0].title).toBe('Second')
+  })
+
+  it('caps delay to 24 hours for very distant times', () => {
+    vi.setSystemTime(new Date('2026-03-15T10:00:00Z'))
+    const farFuture = new Date('2026-03-20T10:00:00Z') // 5 days
+    notificationManager.schedule('far', farFuture, {
+      title: 'Far',
+      body: 'Away',
+    })
+    // Should still be scheduled (capped, not skipped)
+    expect(notificationManager.getScheduled()).toHaveLength(1)
+  })
+})
+
+/* ================================================================== */
+/*  cancel / cancelAll                                                 */
+/* ================================================================== */
+
+describe('cancel', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('cancels a specific scheduled notification', () => {
+    vi.setSystemTime(new Date('2026-03-15T10:00:00Z'))
+    notificationManager.schedule('c1', new Date('2026-03-15T11:00:00Z'), {
+      title: 'C1',
+      body: 'X',
+    })
+    notificationManager.schedule('c2', new Date('2026-03-15T11:00:00Z'), {
+      title: 'C2',
+      body: 'X',
+    })
+    notificationManager.cancel('c1')
+    const scheduled = notificationManager.getScheduled()
+    expect(scheduled).toHaveLength(1)
+    expect(scheduled[0].id).toBe('c2')
+  })
+
+  it('is a no-op for unknown ids', () => {
+    notificationManager.cancel('nonexistent')
+    // should not throw
+  })
+})
+
+describe('cancelAll', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('cancels all scheduled notifications', () => {
+    vi.setSystemTime(new Date('2026-03-15T10:00:00Z'))
+    notificationManager.schedule('a1', new Date('2026-03-15T11:00:00Z'), {
+      title: 'A',
+      body: 'X',
+    })
+    notificationManager.schedule('a2', new Date('2026-03-15T12:00:00Z'), {
+      title: 'B',
+      body: 'X',
+    })
+    notificationManager.cancelAll()
+    expect(notificationManager.getScheduled()).toHaveLength(0)
+  })
+})
+
+/* ================================================================== */
+/*  Batch scheduling: tasks, calendar, meetings                        */
+/* ================================================================== */
+
+describe('scheduleTaskReminders', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('schedules reminders for tasks with due dates', () => {
+    vi.setSystemTime(new Date('2026-03-15T08:00:00Z'))
+    notificationManager.scheduleTaskReminders([
+      { id: 'tk1', title: 'Task 1', due: '2026-03-15T10:00:00Z' },
+      { id: 'tk2', title: 'Task 2', due: '2026-03-15T12:00:00Z' },
+    ])
+    const scheduled = notificationManager.getScheduled()
+    expect(scheduled).toHaveLength(2)
+  })
+
+  it('skips tasks without due dates', () => {
+    vi.setSystemTime(new Date('2026-03-15T08:00:00Z'))
+    notificationManager.scheduleTaskReminders([
+      { id: 'tk3', title: 'No date' },
+      { id: 'tk4', title: 'Has date', due: '2026-03-15T10:00:00Z' },
+    ])
+    expect(notificationManager.getScheduled()).toHaveLength(1)
+  })
+
+  it('uses configured lead time', () => {
+    vi.setSystemTime(new Date('2026-03-15T09:00:00Z'))
+    notificationManager.updateSettings({ taskReminderLeadTime: 60 }) // 1 hour
+    notificationManager.scheduleTaskReminders([
+      { id: 'tk5', title: 'Lead time test', due: '2026-03-15T10:30:00Z' },
+    ])
+    const scheduled = notificationManager.getScheduled()
+    expect(scheduled).toHaveLength(1)
+    // Reminder should be at 09:30 (10:30 - 60min)
+    expect(new Date(scheduled[0].scheduledTime).getUTCHours()).toBe(9)
+    expect(new Date(scheduled[0].scheduledTime).getUTCMinutes()).toBe(30)
+  })
+})
+
+describe('scheduleCalendarReminders', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('schedules reminders for calendar events', () => {
+    vi.setSystemTime(new Date('2026-03-15T08:00:00Z'))
+    notificationManager.scheduleCalendarReminders([
+      { id: 'ev1', summary: 'Meeting', start: '2026-03-15T10:00:00Z' },
+    ])
+    expect(notificationManager.getScheduled()).toHaveLength(1)
+  })
+
+  it('skips events without start times', () => {
+    vi.setSystemTime(new Date('2026-03-15T08:00:00Z'))
+    notificationManager.scheduleCalendarReminders([
+      { id: 'ev2', summary: 'No start' },
+    ])
+    expect(notificationManager.getScheduled()).toHaveLength(0)
+  })
+})
+
+describe('scheduleMeetingReminders', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('schedules reminders for meetings', () => {
+    vi.setSystemTime(new Date('2026-03-15T08:00:00Z'))
+    notificationManager.scheduleMeetingReminders([
+      {
+        id: 'mt1',
+        summary: 'Sprint',
+        start: '2026-03-15T10:00:00Z',
+        meetLink: 'https://meet.google.com/abc',
+      },
+    ])
+    expect(notificationManager.getScheduled()).toHaveLength(1)
+  })
+})
+
+/* ================================================================== */
+/*  Settings                                                           */
+/* ================================================================== */
+
+describe('updateSettings / getSettings', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('merges new settings with existing', () => {
+    notificationManager.updateSettings({ taskReminderLeadTime: 60 })
+    const s = notificationManager.getSettings()
+    expect(s.taskReminderLeadTime).toBe(60)
+    expect(s.enabled).toBe(true) // preserved
+  })
+
+  it('returns a copy (not a reference)', () => {
+    const s1 = notificationManager.getSettings()
+    s1.enabled = false
+    const s2 = notificationManager.getSettings()
+    expect(s2.enabled).toBe(true)
+  })
+})
+
+/* ================================================================== */
+/*  getScheduled                                                       */
+/* ================================================================== */
+
+describe('getScheduled', () => {
+  beforeEach(() => notificationManager.init())
+
+  it('returns empty array when nothing is scheduled', () => {
+    expect(notificationManager.getScheduled()).toEqual([])
+  })
+
+  it('returns id, scheduledTime, and title', () => {
+    vi.setSystemTime(new Date('2026-03-15T10:00:00Z'))
+    notificationManager.schedule('info1', new Date('2026-03-15T11:00:00Z'), {
+      title: 'Info',
+      body: 'Test',
+    })
+    const [entry] = notificationManager.getScheduled()
+    expect(entry).toHaveProperty('id', 'info1')
+    expect(entry).toHaveProperty('scheduledTime')
+    expect(entry).toHaveProperty('title', 'Info')
+  })
+})

--- a/dashboard/electron/__tests__/setup.mjs
+++ b/dashboard/electron/__tests__/setup.mjs
@@ -1,0 +1,137 @@
+/**
+ * Vitest setup for Electron main-process tests
+ *
+ * Strategy: inject mocks into require.cache BEFORE the SUT loads,
+ * so every `require('electron')` / `require('googleapis')` etc.
+ * returns our fakes instead of the real (unavailable) native modules.
+ */
+
+import { vi } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+
+/* ------------------------------------------------------------------ */
+/*  Helper: inject a mock at both the string key AND the resolved path */
+/* ------------------------------------------------------------------ */
+
+function injectMock(moduleName, exports) {
+  const entry = {
+    id: moduleName,
+    filename: moduleName,
+    loaded: true,
+    exports,
+  }
+
+  // Inject at bare name (fallback)
+  require.cache[moduleName] = entry
+
+  // Inject at the resolved path (what CJS require() actually uses)
+  try {
+    const resolved = require.resolve(moduleName)
+    require.cache[resolved] = { ...entry, id: resolved, filename: resolved }
+  } catch {
+    // Module not installed — bare-name injection is sufficient
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Electron mock                                                      */
+/* ------------------------------------------------------------------ */
+
+const mockNotification = {
+  isSupported: vi.fn(() => true),
+}
+
+const mockNativeImage = {
+  createFromPath: vi.fn(() => ({})),
+}
+
+const mockApp = {
+  getAppPath: vi.fn(() => '/tmp/fake-app'),
+  getPath: vi.fn((name) => `/tmp/fake-app/${name}`),
+  isReady: vi.fn(() => true),
+  getName: vi.fn(() => 'googol-vibe'),
+  getVersion: vi.fn(() => '1.0.0'),
+}
+
+const electronMock = {
+  Notification: Object.assign(
+    vi.fn(function (opts) {
+      this.title = opts?.title
+      this.body = opts?.body
+      this.subtitle = opts?.subtitle
+      this._handlers = {}
+      this.on = vi.fn((evt, cb) => { this._handlers[evt] = cb })
+      this.show = vi.fn()
+      this.close = vi.fn()
+    }),
+    { isSupported: mockNotification.isSupported }
+  ),
+  nativeImage: mockNativeImage,
+  app: mockApp,
+  ipcMain: { handle: vi.fn(), on: vi.fn() },
+  BrowserWindow: vi.fn(),
+  safeStorage: {
+    isEncryptionAvailable: vi.fn(() => true),
+    encryptString: vi.fn((s) => Buffer.from(s)),
+    decryptString: vi.fn((b) => b.toString()),
+  },
+}
+
+injectMock('electron', electronMock)
+
+/* ------------------------------------------------------------------ */
+/*  googleapis mock                                                    */
+/* ------------------------------------------------------------------ */
+
+function makeListStub(items = []) {
+  return vi.fn().mockResolvedValue({ data: { items, messages: items, files: items } })
+}
+
+const googleapisMock = {
+  google: {
+    gmail: vi.fn(() => ({
+      users: {
+        messages: {
+          list: makeListStub(),
+          get: vi.fn().mockResolvedValue({
+            data: { payload: { headers: [] }, labelIds: [] },
+          }),
+        },
+      },
+    })),
+    calendar: vi.fn(() => ({
+      events: {
+        list: makeListStub(),
+      },
+    })),
+    tasks: vi.fn(() => ({
+      tasklists: { list: makeListStub() },
+      tasks: { list: makeListStub() },
+    })),
+    drive: vi.fn(() => ({
+      files: { list: makeListStub() },
+    })),
+  },
+}
+
+injectMock('googleapis', googleapisMock)
+
+/* ------------------------------------------------------------------ */
+/*  @sentry/electron/main mock                                         */
+/* ------------------------------------------------------------------ */
+
+const sentryMock = {
+  init: vi.fn(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}
+
+injectMock('@sentry/electron/main', sentryMock)
+
+/* ------------------------------------------------------------------ */
+/*  Export for test files                                               */
+/* ------------------------------------------------------------------ */
+
+export { electronMock, googleapisMock, sentryMock, mockNotification, mockApp }

--- a/dashboard/electron/__tests__/sync-controller.test.mjs
+++ b/dashboard/electron/__tests__/sync-controller.test.mjs
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+
+let syncController
+
+// Stub notification-manager before loading sync-controller
+const notifStub = {
+  showEmailNotification: vi.fn(),
+  show: vi.fn(),
+  scheduleCalendarReminders: vi.fn(),
+  scheduleMeetingReminders: vi.fn(),
+  scheduleTaskReminders: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+
+  // Inject notification-manager stub into require.cache
+  const nmPath = require.resolve('../notification-manager.js')
+  require.cache[nmPath] = {
+    id: nmPath,
+    filename: nmPath,
+    loaded: true,
+    exports: notifStub,
+  }
+
+  // Clear sync-controller cache to get a fresh singleton
+  const scPath = require.resolve('../sync-controller.js')
+  delete require.cache[scPath]
+  syncController = require('../sync-controller.js')
+})
+
+afterEach(() => {
+  syncController.stop()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
+
+/* ================================================================== */
+/*  Constructor / init                                                 */
+/* ================================================================== */
+
+describe('constructor', () => {
+  it('starts with null authClient and mainWindow', () => {
+    expect(syncController.authClient).toBeNull()
+    expect(syncController.mainWindow).toBeNull()
+  })
+
+  it('has empty interval handles', () => {
+    for (const key of Object.keys(syncController.intervals)) {
+      expect(syncController.intervals[key]).toBeNull()
+    }
+  })
+
+  it('has zero new item counts', () => {
+    for (const key of Object.keys(syncController.newItemCounts)) {
+      expect(syncController.newItemCounts[key]).toBe(0)
+    }
+  })
+})
+
+describe('init', () => {
+  it('stores authClient and mainWindow references', () => {
+    const auth = { credentials: 'mock' }
+    const win = { webContents: { send: vi.fn() }, isDestroyed: () => false }
+    syncController.init(auth, win)
+    expect(syncController.authClient).toBe(auth)
+    expect(syncController.mainWindow).toBe(win)
+  })
+})
+
+describe('setAuthClient / setMainWindow', () => {
+  it('updates authClient', () => {
+    const auth = { token: 'new' }
+    syncController.setAuthClient(auth)
+    expect(syncController.authClient).toBe(auth)
+  })
+
+  it('updates mainWindow', () => {
+    const win = { webContents: { send: vi.fn() }, isDestroyed: () => false }
+    syncController.setMainWindow(win)
+    expect(syncController.mainWindow).toBe(win)
+  })
+})
+
+/* ================================================================== */
+/*  start / stop                                                       */
+/* ================================================================== */
+
+describe('start', () => {
+  it('does nothing without authClient', () => {
+    syncController.start()
+    // All intervals should remain null
+    for (const key of Object.keys(syncController.intervals)) {
+      expect(syncController.intervals[key]).toBeNull()
+    }
+  })
+
+  it('sets up intervals when authClient is present', () => {
+    syncController.init({ token: 'x' }, null)
+    syncController.start()
+    for (const key of Object.keys(syncController.intervals)) {
+      expect(syncController.intervals[key]).not.toBeNull()
+    }
+  })
+})
+
+describe('stop', () => {
+  it('clears all intervals', () => {
+    syncController.init({ token: 'x' }, null)
+    syncController.start()
+    syncController.stop()
+    for (const key of Object.keys(syncController.intervals)) {
+      expect(syncController.intervals[key]).toBeNull()
+    }
+  })
+
+  it('is safe to call when not started', () => {
+    syncController.stop() // should not throw
+  })
+})
+
+/* ================================================================== */
+/*  Sync guard flags                                                   */
+/* ================================================================== */
+
+describe('sync guard flags', () => {
+  it('prevents concurrent gmail syncs', async () => {
+    syncController.syncing.gmail = true
+    syncController.authClient = { token: 'x' }
+    await syncController.syncGmail()
+    // Should return early without changing lastSync
+    expect(syncController.lastSync.gmail).toBeNull()
+  })
+
+  it('prevents sync without authClient', async () => {
+    syncController.authClient = null
+    await syncController.syncGmail()
+    expect(syncController.lastSync.gmail).toBeNull()
+  })
+
+  it('resets syncing flag after completion', async () => {
+    syncController.authClient = { token: 'x' }
+    await syncController.syncGmail()
+    expect(syncController.syncing.gmail).toBe(false)
+  })
+
+  it('resets syncing flag after calendar sync', async () => {
+    syncController.authClient = { token: 'x' }
+    await syncController.syncCalendar()
+    expect(syncController.syncing.calendar).toBe(false)
+  })
+
+  it('resets syncing flag after tasks sync', async () => {
+    syncController.authClient = { token: 'x' }
+    await syncController.syncTasks()
+    expect(syncController.syncing.tasks).toBe(false)
+  })
+
+  it('resets syncing flag after drive sync', async () => {
+    syncController.authClient = { token: 'x' }
+    await syncController.syncDrive()
+    expect(syncController.syncing.drive).toBe(false)
+  })
+})
+
+/* ================================================================== */
+/*  getStatus                                                          */
+/* ================================================================== */
+
+describe('getStatus', () => {
+  it('returns status for all four services', () => {
+    const status = syncController.getStatus()
+    expect(status).toHaveProperty('gmail')
+    expect(status).toHaveProperty('calendar')
+    expect(status).toHaveProperty('tasks')
+    expect(status).toHaveProperty('drive')
+    expect(status).toHaveProperty('intervals')
+  })
+
+  it('reports correct interval durations in seconds', () => {
+    const status = syncController.getStatus()
+    expect(status.intervals.gmail).toBe(30)
+    expect(status.intervals.calendar).toBe(60)
+    expect(status.intervals.tasks).toBe(60)
+    expect(status.intervals.drive).toBe(120)
+  })
+
+  it('shows "Pending..." when no sync has occurred', () => {
+    const status = syncController.getStatus()
+    expect(status.gmail.nextSync).toBe('Pending...')
+  })
+
+  it('shows syncing state', () => {
+    syncController.syncing.gmail = true
+    const status = syncController.getStatus()
+    expect(status.gmail.syncing).toBe(true)
+  })
+})
+
+/* ================================================================== */
+/*  resetNewItemCounts                                                 */
+/* ================================================================== */
+
+describe('resetNewItemCounts', () => {
+  it('resets all counts to zero', () => {
+    syncController.newItemCounts.gmail = 5
+    syncController.newItemCounts.calendar = 3
+    syncController.resetNewItemCounts()
+    for (const key of Object.keys(syncController.newItemCounts)) {
+      expect(syncController.newItemCounts[key]).toBe(0)
+    }
+  })
+})
+
+/* ================================================================== */
+/*  forceSync                                                          */
+/* ================================================================== */
+
+describe('forceSync', () => {
+  it('calls syncGmail for "gmail"', async () => {
+    const spy = vi.spyOn(syncController, 'syncGmail').mockResolvedValue()
+    await syncController.forceSync('gmail')
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('calls syncAll for "all"', async () => {
+    const spy = vi.spyOn(syncController, 'syncAll').mockResolvedValue()
+    await syncController.forceSync('all')
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('handles unknown service gracefully', async () => {
+    await syncController.forceSync('unknown') // should not throw
+  })
+})
+
+/* ================================================================== */
+/*  notifyRenderer                                                     */
+/* ================================================================== */
+
+describe('notifyRenderer', () => {
+  it('sends event to mainWindow', () => {
+    const send = vi.fn()
+    syncController.mainWindow = {
+      isDestroyed: () => false,
+      webContents: { send },
+    }
+    syncController.notifyRenderer('test-event', { data: 1 })
+    expect(send).toHaveBeenCalledWith('test-event', { data: 1 })
+  })
+
+  it('does nothing when mainWindow is null', () => {
+    syncController.mainWindow = null
+    syncController.notifyRenderer('test-event', {}) // should not throw
+  })
+
+  it('does nothing when mainWindow is destroyed', () => {
+    syncController.mainWindow = {
+      isDestroyed: () => true,
+      webContents: { send: vi.fn() },
+    }
+    syncController.notifyRenderer('test-event', {})
+    expect(syncController.mainWindow.webContents.send).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/electron/__tests__/telemetry.test.mjs
+++ b/dashboard/electron/__tests__/telemetry.test.mjs
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createRequire } from 'module'
+import { sentryMock } from './setup.mjs'
+
+const require = createRequire(import.meta.url)
+
+let telemetry
+
+// Shared config-manager stub
+const configStub = {
+  isTelemetryEnabled: vi.fn(() => false),
+  setTelemetryEnabled: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  sentryMock.init.mockClear()
+  sentryMock.captureException.mockClear()
+  sentryMock.captureMessage.mockClear()
+  configStub.isTelemetryEnabled.mockReturnValue(false)
+  configStub.setTelemetryEnabled.mockClear()
+
+  // Inject config-manager stub
+  const cmPath = require.resolve('../config-manager.js')
+  require.cache[cmPath] = {
+    id: cmPath,
+    filename: cmPath,
+    loaded: true,
+    exports: configStub,
+  }
+
+  // Clear telemetry cache for fresh state
+  const telPath = require.resolve('../telemetry.js')
+  delete require.cache[telPath]
+
+  // Set DSN so init can proceed
+  process.env.SENTRY_DSN = 'https://fake@sentry.io/123'
+  process.env.NODE_ENV = 'production'
+
+  telemetry = require('../telemetry.js')
+})
+
+afterEach(() => {
+  delete process.env.SENTRY_DSN
+  delete process.env.NODE_ENV
+})
+
+/* ================================================================== */
+/*  Opt-in gate                                                        */
+/* ================================================================== */
+
+describe('opt-in gate', () => {
+  it('returns false when telemetry is disabled', () => {
+    configStub.isTelemetryEnabled.mockReturnValue(false)
+    expect(telemetry.initTelemetry()).toBe(false)
+  })
+
+  it('initialises Sentry when telemetry is enabled', () => {
+    configStub.isTelemetryEnabled.mockReturnValue(true)
+    const result = telemetry.initTelemetry()
+    expect(result).toBe(true)
+    expect(sentryMock.init).toHaveBeenCalled()
+  })
+
+  it('returns false when DSN is empty', () => {
+    configStub.isTelemetryEnabled.mockReturnValue(true)
+    delete process.env.SENTRY_DSN
+
+    // Need fresh module to pick up empty DSN
+    const telPath = require.resolve('../telemetry.js')
+    delete require.cache[telPath]
+    const freshTelemetry = require('../telemetry.js')
+    expect(freshTelemetry.initTelemetry()).toBe(false)
+  })
+})
+
+/* ================================================================== */
+/*  Sentry init                                                        */
+/* ================================================================== */
+
+describe('initTelemetry', () => {
+  it('only initialises once (idempotent)', () => {
+    configStub.isTelemetryEnabled.mockReturnValue(true)
+    telemetry.initTelemetry()
+    telemetry.initTelemetry()
+    expect(sentryMock.init).toHaveBeenCalledTimes(1)
+  })
+})
+
+/* ================================================================== */
+/*  captureError / captureMessage                                      */
+/* ================================================================== */
+
+describe('captureError', () => {
+  it('does nothing when Sentry is not initialised', () => {
+    telemetry.captureError(new Error('test'))
+    expect(sentryMock.captureException).not.toHaveBeenCalled()
+  })
+
+  it('captures error when Sentry is initialised', () => {
+    configStub.isTelemetryEnabled.mockReturnValue(true)
+    telemetry.initTelemetry()
+    const err = new Error('boom')
+    telemetry.captureError(err, { module: 'sync' })
+    expect(sentryMock.captureException).toHaveBeenCalledWith(err, {
+      extra: { module: 'sync' },
+    })
+  })
+})
+
+describe('captureMessage', () => {
+  it('does nothing when Sentry is not initialised', () => {
+    telemetry.captureMessage('info')
+    expect(sentryMock.captureMessage).not.toHaveBeenCalled()
+  })
+
+  it('captures message when Sentry is initialised', () => {
+    configStub.isTelemetryEnabled.mockReturnValue(true)
+    telemetry.initTelemetry()
+    telemetry.captureMessage('hello', 'warning')
+    expect(sentryMock.captureMessage).toHaveBeenCalledWith('hello', 'warning')
+  })
+})
+
+/* ================================================================== */
+/*  enableTelemetry / disableTelemetry                                 */
+/* ================================================================== */
+
+describe('enableTelemetry', () => {
+  it('saves preference and calls initTelemetry', () => {
+    configStub.isTelemetryEnabled.mockReturnValue(true)
+    telemetry.enableTelemetry()
+    expect(configStub.setTelemetryEnabled).toHaveBeenCalledWith(true)
+  })
+})
+
+describe('disableTelemetry', () => {
+  it('saves preference and returns true', () => {
+    const result = telemetry.disableTelemetry()
+    expect(configStub.setTelemetryEnabled).toHaveBeenCalledWith(false)
+    expect(result).toBe(true)
+  })
+})
+
+/* ================================================================== */
+/*  isEnabled                                                          */
+/* ================================================================== */
+
+describe('isEnabled', () => {
+  it('delegates to configManager', () => {
+    configStub.isTelemetryEnabled.mockReturnValue(true)
+    expect(telemetry.isEnabled()).toBe(true)
+    configStub.isTelemetryEnabled.mockReturnValue(false)
+    expect(telemetry.isEnabled()).toBe(false)
+  })
+})

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -25,8 +25,10 @@
         "build:win": "vite build && electron-builder --win -p never",
         "build:linux": "vite build && electron-builder --linux -p never",
         "build:all": "vite build && electron-builder -mwl -p never",
-        "test": "vitest",
-        "test:run": "vitest run"
+        "test": "vitest run --passWithNoTests && vitest run --config vitest.electron.config.js",
+        "test:watch": "vitest",
+        "test:electron": "vitest run --config vitest.electron.config.js",
+        "test:run": "vitest run --passWithNoTests && vitest run --config vitest.electron.config.js"
     },
     "dependencies": {
         "@google-cloud/local-auth": "^3.0.1",

--- a/dashboard/vitest.config.js
+++ b/dashboard/vitest.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['electron/__tests__/**/*.test.{js,mjs}'],
-    globals: true
+    globals: true,
+    exclude: ['electron/__tests__/**', 'node_modules/**']
   }
 })

--- a/dashboard/vitest.electron.config.js
+++ b/dashboard/vitest.electron.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        globals: true,
+        include: ['electron/__tests__/**/*.test.mjs'],
+        setupFiles: ['./electron/__tests__/setup.mjs'],
+        testTimeout: 10000,
+    },
+})


### PR DESCRIPTION
## Summary

- 81 new Vitest tests for notification-manager (44), sync-controller (26), and telemetry (11)
- Require.cache injection pattern to mock CJS dependencies (electron, googleapis, sentry) that bypass vi.mock
- Separate `vitest.electron.config.js` for node-env electron tests
- Updated test scripts: `test:run` runs both React and Electron suites

## Test plan

- [x] `npm run test:run` passes all 149 tests on Windows (Git Bash)
- [x] notification-manager: quiet hours, overnight wrap, scheduling, lead times, settings
- [x] sync-controller: lifecycle, syncAll, individual syncs, guard flags, forceSync, status
- [x] telemetry: opt-in gate, Sentry init, captureError/captureMessage, enable/disable
- [x] Existing config-manager tests (68) still pass

Closes #9