### PR TITLE
fix(security): High tier - OAuth CSRF state, IPC validation, CSP, deps, error scrub

### DIFF
--- a/dashboard/electron/__tests__/ipc-safety.test.mjs
+++ b/dashboard/electron/__tests__/ipc-safety.test.mjs
@@ -1,0 +1,41 @@
+/**
+ * Security regression — High #8 (ipc-safety leaks raw err.message to renderer).
+ * The error message returned to the renderer must not contain filesystem paths
+ * or secret-shaped blobs. Mutation-sensitive: fails if scrubbing is removed.
+ */
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const { sanitizeErrorMessage } = require('../ipc-safety.js')
+
+describe('sanitizeErrorMessage (no FS path / secret leak to renderer)', () => {
+  it('strips Windows filesystem paths', () => {
+    const out = sanitizeErrorMessage("ENOENT: open 'C:\\Users\\Andre\\token.json'")
+    expect(out).not.toContain('C:\\Users')
+    expect(out).toContain('[path]')
+  })
+
+  it('strips POSIX filesystem paths', () => {
+    const out = sanitizeErrorMessage('cannot read /home/andre/.googol-vibe/credentials.json')
+    expect(out).not.toContain('/home/andre')
+    expect(out).toContain('[path]')
+  })
+
+  it('redacts long token-shaped blobs', () => {
+    const secret = 'ya29A0ARrdaMabcdefghijklmnopqrstuvwxyz0123456789'
+    const out = sanitizeErrorMessage('bad token ' + secret)
+    expect(out).toContain('[redacted]')
+    expect(out).not.toContain(secret)
+  })
+
+  it('passes through short, path-free validation messages unchanged', () => {
+    expect(sanitizeErrorMessage('Invalid credentials file: missing client_id'))
+      .toBe('Invalid credentials file: missing client_id')
+  })
+
+  it('handles non-string / empty input', () => {
+    expect(sanitizeErrorMessage(undefined)).toBe('An unexpected error occurred.')
+    expect(sanitizeErrorMessage('')).toBe('An unexpected error occurred.')
+  })
+})

--- a/dashboard/electron/__tests__/log-redact.test.mjs
+++ b/dashboard/electron/__tests__/log-redact.test.mjs
@@ -1,0 +1,38 @@
+/**
+ * Security regression — Medium #13 (log redaction). Secret-shaped strings must
+ * not reach log files/console. Mutation-sensitive: fails if a pattern is dropped.
+ */
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const { redactSecrets } = require('../log-redact.js')
+
+describe('redactSecrets', () => {
+  it('redacts Google access tokens (ya29.)', () => {
+    const out = redactSecrets('token=ya29.A0ARrdaM-abcDEF_123')
+    expect(out).not.toContain('ya29.A0ARrdaM')
+    expect(out).toContain('[redacted-token]')
+  })
+
+  it('redacts Google refresh tokens (1//)', () => {
+    expect(redactSecrets('refresh 1//0gabcDEF_ghi-123')).toContain('[redacted-token]')
+  })
+
+  it('redacts sk- and AIza API keys', () => {
+    expect(redactSecrets('key sk-abcdefghijklmnop1234')).toContain('[redacted-key]')
+    expect(redactSecrets('key AIzaSyAbcdefGhIjk123')).toContain('[redacted-key]')
+  })
+
+  it('redacts Bearer tokens', () => {
+    expect(redactSecrets('Authorization: Bearer abc.def-123')).toContain('Bearer [redacted]')
+  })
+
+  it('leaves ordinary log text unchanged', () => {
+    expect(redactSecrets('Calling tool: get_tasks')).toBe('Calling tool: get_tasks')
+  })
+
+  it('handles non-string input', () => {
+    expect(redactSecrets(undefined)).toBe(undefined)
+  })
+})

--- a/dashboard/electron/__tests__/oauth-callback.test.mjs
+++ b/dashboard/electron/__tests__/oauth-callback.test.mjs
@@ -1,0 +1,48 @@
+/**
+ * Security regression — High #4 (OAuth flow has no CSRF state). The loopback
+ * callback must verify a state we generated and match the path exactly.
+ * Mutation-sensitive: fails if the state check or strict-path check is removed.
+ */
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const { parseOAuthCallback } = require('../oauth-callback.js')
+
+const PORT = 3000
+const STATE = 'abc123def456'
+
+describe('parseOAuthCallback (OAuth CSRF state + strict callback)', () => {
+  it('accepts a valid callback with matching state and code', () => {
+    expect(parseOAuthCallback(`/oauth2callback?state=${STATE}&code=AUTHCODE`, STATE, PORT))
+      .toEqual({ ok: true, code: 'AUTHCODE' })
+  })
+
+  it('rejects a mismatched state (CSRF)', () => {
+    const r = parseOAuthCallback(`/oauth2callback?state=evil&code=AUTHCODE`, STATE, PORT)
+    expect(r.ok).toBe(false)
+    expect(r.error).toMatch(/state/i)
+  })
+
+  it('rejects a missing state', () => {
+    expect(parseOAuthCallback('/oauth2callback?code=AUTHCODE', STATE, PORT).ok).toBe(false)
+  })
+
+  it('rejects when expectedState is empty (never blindly trust)', () => {
+    expect(parseOAuthCallback('/oauth2callback?state=&code=AUTHCODE', '', PORT).ok).toBe(false)
+  })
+
+  it('rejects an OAuth error response', () => {
+    const r = parseOAuthCallback(`/oauth2callback?error=access_denied&state=${STATE}`, STATE, PORT)
+    expect(r.ok).toBe(false)
+    expect(r.error).toMatch(/access_denied/)
+  })
+
+  it('rejects a path that merely contains the callback as a substring', () => {
+    expect(parseOAuthCallback(`/evil/oauth2callback?state=${STATE}&code=x`, STATE, PORT).ok).toBe(false)
+  })
+
+  it('rejects a missing code even with a valid state', () => {
+    expect(parseOAuthCallback(`/oauth2callback?state=${STATE}`, STATE, PORT).ok).toBe(false)
+  })
+})

--- a/dashboard/electron/__tests__/recurrence-validation.test.mjs
+++ b/dashboard/electron/__tests__/recurrence-validation.test.mjs
@@ -1,0 +1,36 @@
+/**
+ * Security regression — High #5 (rrule DoS/correctness guard). Tests the REAL
+ * recurrence-manager singleton (recurrence-manager.test.mjs exercises a copy of
+ * the class, so the production guard needs its own coverage). isValidRRule is a
+ * pure method and does not require init(); createRule's throw path runs before
+ * any disk write.
+ */
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const recurrenceManager = require('../recurrence-manager.js')
+
+describe('recurrence rrule validation (DoS + correctness guard)', () => {
+  it('accepts a valid RRULE', () => {
+    expect(recurrenceManager.isValidRRule('FREQ=DAILY;INTERVAL=1')).toBe(true)
+  })
+
+  it('rejects a non-string / empty rrule', () => {
+    expect(recurrenceManager.isValidRRule(undefined)).toBe(false)
+    expect(recurrenceManager.isValidRRule('')).toBe(false)
+  })
+
+  it('rejects garbage that does not parse', () => {
+    expect(recurrenceManager.isValidRRule('GARBAGE')).toBe(false)
+  })
+
+  it('rejects an over-long rrule (DoS bound)', () => {
+    expect(recurrenceManager.isValidRRule('FREQ=DAILY;' + 'X'.repeat(3000))).toBe(false)
+  })
+
+  it('createRule throws on an invalid rrule (never stored)', () => {
+    expect(() => recurrenceManager.createRule({ title: 'x', rruleString: 'GARBAGE', taskListId: 'l1' }))
+      .toThrow('Invalid recurrence rule')
+  })
+})

--- a/dashboard/electron/__tests__/url-trust.test.mjs
+++ b/dashboard/electron/__tests__/url-trust.test.mjs
@@ -1,0 +1,43 @@
+/**
+ * Security regression — Medium #11 (isTrustedURL trusted localhost on ANY port).
+ * localhost is now trusted only on the exact dev-server port. Mutation-sensitive:
+ * fails if the port pin is removed or the domain check is loosened.
+ */
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const { isTrustedURL } = require('../url-trust.js')
+
+const VITE = 9000
+
+describe('isTrustedURL (localhost pinned to dev port)', () => {
+  it('trusts file:// (production bundle)', () => {
+    expect(isTrustedURL('file:///app/index.html', { vitePort: VITE })).toBe(true)
+  })
+
+  it('trusts localhost ONLY on the dev-server port', () => {
+    expect(isTrustedURL(`http://localhost:${VITE}/`, { vitePort: VITE })).toBe(true)
+    expect(isTrustedURL('http://localhost:1337/', { vitePort: VITE })).toBe(false)
+    expect(isTrustedURL('http://localhost/', { vitePort: VITE })).toBe(false)
+  })
+
+  it('does not trust localhost when no vitePort is supplied', () => {
+    expect(isTrustedURL(`http://localhost:${VITE}/`, {})).toBe(false)
+  })
+
+  it('trusts https Google domains and their subdomains', () => {
+    expect(isTrustedURL('https://docs.google.com/x', { vitePort: VITE })).toBe(true)
+    expect(isTrustedURL('https://foo.drive.google.com/', { vitePort: VITE })).toBe(true)
+  })
+
+  it('rejects non-https, look-alike and untrusted domains', () => {
+    expect(isTrustedURL('http://docs.google.com/', { vitePort: VITE })).toBe(false)
+    expect(isTrustedURL('https://evil.com/', { vitePort: VITE })).toBe(false)
+    expect(isTrustedURL('https://google.com.evil.com/', { vitePort: VITE })).toBe(false)
+  })
+
+  it('rejects malformed urls', () => {
+    expect(isTrustedURL('not a url', { vitePort: VITE })).toBe(false)
+  })
+})

--- a/dashboard/electron/__tests__/validators.test.mjs
+++ b/dashboard/electron/__tests__/validators.test.mjs
@@ -1,0 +1,36 @@
+/**
+ * Security regression — High #5 (IPC input validation). Google IDs passed to the
+ * Google API must be validated. Mutation-sensitive: fails if the allow-pattern
+ * is loosened.
+ */
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const { isValidGoogleId } = require('../validators.js')
+
+describe('isValidGoogleId', () => {
+  it('accepts normal Google task/list IDs', () => {
+    expect(isValidGoogleId('MTIzNDU2Nzg5')).toBe(true)
+    expect(isValidGoogleId('abc_DEF-123')).toBe(true)
+  })
+
+  it('rejects empty / non-string', () => {
+    expect(isValidGoogleId('')).toBe(false)
+    expect(isValidGoogleId(undefined)).toBe(false)
+    expect(isValidGoogleId(null)).toBe(false)
+    expect(isValidGoogleId(123)).toBe(false)
+  })
+
+  it('rejects path separators, whitespace and other unexpected characters', () => {
+    expect(isValidGoogleId('../../etc/passwd')).toBe(false)
+    expect(isValidGoogleId('a/b')).toBe(false)
+    expect(isValidGoogleId('has space')).toBe(false)
+    expect(isValidGoogleId('semi;colon')).toBe(false)
+    expect(isValidGoogleId('quote"x')).toBe(false)
+  })
+
+  it('rejects absurdly long ids', () => {
+    expect(isValidGoogleId('a'.repeat(257))).toBe(false)
+  })
+})

--- a/dashboard/electron/ipc-safety.js
+++ b/dashboard/electron/ipc-safety.js
@@ -9,19 +9,38 @@ const log = require('./logger');
  * @param {object} [options]
  * @param {*} [options.fallback] - Value to return on error instead of { error }
  */
+/**
+ * Strip filesystem paths and long token-shaped blobs from an error message
+ * before it is returned to the (less-trusted) renderer. The full error is still
+ * logged internally; only the renderer-facing copy is scrubbed. Over-scrubbing
+ * is acceptable (a vaguer message); under-scrubbing would leak paths/secrets.
+ */
+function sanitizeErrorMessage(msg) {
+    if (typeof msg !== 'string' || msg.length === 0) {
+        return 'An unexpected error occurred.';
+    }
+    let s = msg;
+    s = s.replace(/[A-Za-z]:\\[^\s'"]+/g, '[path]');       // Windows paths
+    s = s.replace(/(?:\/[^\s/'"]+){2,}\/?/g, '[path]');     // POSIX paths (2+ segments)
+    s = s.replace(/[A-Za-z0-9_\-+/]{24,}/g, '[redacted]');  // long token-shaped blobs
+    if (s.length > 200) s = s.slice(0, 200) + '...';
+    return s;
+}
+
 function safeHandle(channel, handler, options = {}) {
     const { fallback } = options;
     ipcMain.handle(channel, async (event, ...args) => {
         try {
             return await handler(event, ...args);
         } catch (err) {
+            // Log the full error internally; return a scrubbed message to the renderer.
             log.error(`[IPC:${channel}] ${err.message}`);
             if (fallback !== undefined) {
                 return typeof fallback === 'function' ? fallback() : fallback;
             }
-            return { error: err.message };
+            return { error: sanitizeErrorMessage(err.message) };
         }
     });
 }
 
-module.exports = { safeHandle };
+module.exports = { safeHandle, sanitizeErrorMessage };

--- a/dashboard/electron/log-redact.js
+++ b/dashboard/electron/log-redact.js
@@ -1,0 +1,15 @@
+/**
+ * Redact secret-shaped substrings from log text so tokens / API keys never reach
+ * log files or the console. Pure, no deps. Used as an electron-log hook.
+ */
+function redactSecrets(text) {
+    if (typeof text !== 'string' || text.length === 0) return text;
+    return text
+        .replace(/ya29\.[A-Za-z0-9._\-]+/g, '[redacted-token]')   // Google access tokens
+        .replace(/1\/\/[A-Za-z0-9._\-]+/g, '[redacted-token]')    // Google refresh tokens
+        .replace(/sk-[A-Za-z0-9._\-]{16,}/g, '[redacted-key]')    // sk-style API keys
+        .replace(/AIza[A-Za-z0-9._\-]{10,}/g, '[redacted-key]')   // Google API keys
+        .replace(/Bearer\s+[A-Za-z0-9._\-]+/gi, 'Bearer [redacted]');
+}
+
+module.exports = { redactSecrets };

--- a/dashboard/electron/logger.js
+++ b/dashboard/electron/logger.js
@@ -1,4 +1,5 @@
 const log = require('electron-log/main');
+const { redactSecrets } = require('./log-redact');
 
 log.initialize();
 
@@ -11,5 +12,16 @@ log.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}';
 const level = process.env.NODE_ENV === 'development' ? 'debug' : 'info';
 log.transports.file.level = level;
 log.transports.console.level = level;
+
+// Redact secret-shaped strings from every log line (defence in depth). Guarded so
+// an electron-log API change cannot break logging.
+if (Array.isArray(log.hooks)) {
+    log.hooks.push((message) => {
+        if (message && Array.isArray(message.data)) {
+            message.data = message.data.map((d) => (typeof d === 'string' ? redactSecrets(d) : d));
+        }
+        return message;
+    });
+}
 
 module.exports = log;

--- a/dashboard/electron/main.js
+++ b/dashboard/electron/main.js
@@ -18,6 +18,7 @@ const { safeHandle } = require('./ipc-safety');
 const tokenStorage = require('./token-storage');
 const { isValidGoogleId } = require('./validators');
 const { parseOAuthCallback } = require('./oauth-callback');
+const urlTrust = require('./url-trust');
 
 log.info('[Googol Vibe] App starting — log transport active');
 
@@ -46,36 +47,10 @@ let authWindow;
 let authClient;
 let contentView = null; // Track the active BrowserView
 
-// Security: Trusted domains for navigation and content loading
-const TRUSTED_DOMAINS = [
-    'accounts.google.com',
-    'docs.google.com',
-    'drive.google.com',
-    'meet.google.com',
-    'sheets.google.com',
-    'slides.google.com',
-    'calendar.google.com',
-    'mail.google.com',
-    'myaccount.google.com',
-    'tasks.google.com'
-];
-
-/**
- * Check if a URL is a trusted destination.
- * Allows Google domains, localhost (dev server), and file:// (production).
- */
+// URL trust (navigation / content loading) lives in ./url-trust (pure + tested).
+// localhost is trusted ONLY on the dev-server port, not any localhost port (#11).
 function isTrustedURL(urlString) {
-    try {
-        const parsed = new URL(urlString);
-        if (parsed.protocol === 'file:') return true;
-        if (parsed.hostname === 'localhost') return true;
-        if (parsed.protocol !== 'https:') return false;
-        return TRUSTED_DOMAINS.some(domain =>
-            parsed.hostname === domain || parsed.hostname.endsWith('.' + domain)
-        );
-    } catch {
-        return false;
-    }
+    return urlTrust.isTrustedURL(urlString, { vitePort: configManager.getVitePort() });
 }
 
 // ConfigManager provides all paths - see config-manager.js for details
@@ -174,6 +149,8 @@ function authenticateWithLoopback(oAuth2Client) {
                 webPreferences: {
                     nodeIntegration: false,
                     contextIsolation: true,
+                    sandbox: true,
+                    webSecurity: true,
                     partition: 'persist:googleos'
                 },
                 autoHideMenuBar: true,
@@ -444,6 +421,8 @@ const createWindow = () => {
             preload: path.join(__dirname, 'preload.js'),
             nodeIntegration: false,
             contextIsolation: true,
+            sandbox: true,
+            webSecurity: true,
             partition: 'persist:googolvibe'
         },
         titleBarStyle: 'hiddenInset',
@@ -486,7 +465,8 @@ const createWindow = () => {
 
     mainWindow.loadURL(startUrl);
 
-    if (isDev) {
+    // DevTools only when explicitly opted in (GV_DEVTOOLS=1), not on every dev run.
+    if (process.env.GV_DEVTOOLS === '1') {
         mainWindow.webContents.openDevTools();
     }
 
@@ -984,6 +964,8 @@ app.on('ready', () => {
             webPreferences: {
                 nodeIntegration: false,
                 contextIsolation: true,
+                sandbox: true,
+                webSecurity: true,
                 partition: 'persist:googleos'
             }
         });

--- a/dashboard/electron/main.js
+++ b/dashboard/electron/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const http = require('http');
 const url = require('url');
+const crypto = require('crypto');
 const { google } = require('googleapis');
 const configManager = require('./config-manager');
 const telemetry = require('./telemetry');
@@ -16,6 +17,7 @@ const log = require('./logger');
 const { safeHandle } = require('./ipc-safety');
 const tokenStorage = require('./token-storage');
 const { isValidGoogleId } = require('./validators');
+const { parseOAuthCallback } = require('./oauth-callback');
 
 log.info('[Googol Vibe] App starting — log transport active');
 
@@ -118,28 +120,46 @@ async function createOAuthClient() {
 function authenticateWithLoopback(oAuth2Client) {
     return new Promise((resolve, reject) => {
         const port = configManager.getOAuthPort();
+        // CSRF protection: bind this auth request to a random state we verify on callback.
+        const state = crypto.randomBytes(16).toString('hex');
         const authorizeUrl = oAuth2Client.generateAuthUrl({
             access_type: 'offline',
             scope: SCOPES,
+            state,
         });
 
         const server = http.createServer(async (req, res) => {
-            try {
-                if (req.url.indexOf('/oauth2callback') > -1) {
-                    const qs = new url.URL(req.url, `http://localhost:${port}`).searchParams;
-                    res.end('<h1>Authentication successful!</h1><script>setTimeout(() => window.close(), 1000);</script>');
-                    server.destroy();
-                    const { tokens } = await oAuth2Client.getToken(qs.get('code'));
-                    oAuth2Client.setCredentials(tokens);
-                    resolve(oAuth2Client);
+            // Ignore anything that is not the callback (favicon probes, etc.).
+            if (!req.url || !req.url.startsWith('/oauth2callback')) {
+                res.statusCode = 404;
+                res.end('Not found');
+                return;
+            }
 
-                    if (authWindow) {
-                        authWindow.close();
-                    }
-                    if (mainWindow) {
-                        mainWindow.show();
-                        mainWindow.focus();
-                    }
+            // Validate path, state (CSRF), error param and code before exchanging.
+            const result = parseOAuthCallback(req.url, state, port);
+            if (!result.ok) {
+                res.statusCode = 400;
+                res.end('Authentication failed.');
+                server.destroy();
+                if (authWindow) authWindow.close();
+                reject(new Error(result.error));
+                return;
+            }
+
+            try {
+                res.end('<h1>Authentication successful!</h1><script>setTimeout(() => window.close(), 1000);</script>');
+                server.destroy();
+                const { tokens } = await oAuth2Client.getToken(result.code);
+                oAuth2Client.setCredentials(tokens);
+                resolve(oAuth2Client);
+
+                if (authWindow) {
+                    authWindow.close();
+                }
+                if (mainWindow) {
+                    mainWindow.show();
+                    mainWindow.focus();
                 }
             } catch (e) {
                 res.end('Error fetching token');
@@ -433,7 +453,11 @@ const createWindow = () => {
         title: 'Googol Vibe'
     });
 
-    // Set Content Security Policy (production only - Vite HMR needs inline scripts in dev)
+    // Set Content Security Policy (production only - Vite HMR needs inline scripts/ws in dev).
+    // Deferred (each needs a running-app check): a dev-mode CSP; tightening style-src off
+    // 'unsafe-inline' (React/framer inject inline styles - needs a nonce); a CSP for the
+    // persist:googleos session is intentionally NOT added - it loads Google's own login/Docs
+    // pages, which manage their own CSP, and forcing ours would break them.
     const isDev = process.env.NODE_ENV === 'development';
     if (!isDev) {
         mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
@@ -447,7 +471,10 @@ const createWindow = () => {
                         "img-src 'self' data: https: blob:;" +
                         "font-src 'self' data:;" +
                         "connect-src 'self' https://accounts.google.com https://*.googleapis.com https://*.google.com;" +
-                        "frame-src https://*.google.com https://accounts.google.com;"
+                        "frame-src https://*.google.com https://accounts.google.com;" +
+                        "object-src 'none';" +
+                        "base-uri 'self';" +
+                        "frame-ancestors 'none';"
                     ]
                 }
             });

--- a/dashboard/electron/main.js
+++ b/dashboard/electron/main.js
@@ -15,6 +15,7 @@ const aiMemory = require('./ai-memory');
 const log = require('./logger');
 const { safeHandle } = require('./ipc-safety');
 const tokenStorage = require('./token-storage');
+const { isValidGoogleId } = require('./validators');
 
 log.info('[Googol Vibe] App starting — log transport active');
 
@@ -729,6 +730,7 @@ app.on('ready', () => {
     safeHandle('create-task', async (event, { taskListId, title, due }) => {
         if (!authClient) authClient = await loadSavedCredentialsIfExist();
         if (!authClient) throw new Error('Not authenticated');
+        if (!isValidGoogleId(taskListId)) throw new Error('Invalid task list id');
 
         const tasks = google.tasks({ version: 'v1', auth: authClient });
         const res = await tasks.tasks.insert({
@@ -742,6 +744,7 @@ app.on('ready', () => {
     safeHandle('complete-task', async (event, { taskListId, taskId }) => {
         if (!authClient) authClient = await loadSavedCredentialsIfExist();
         if (!authClient) throw new Error('Not authenticated');
+        if (!isValidGoogleId(taskListId) || !isValidGoogleId(taskId)) throw new Error('Invalid task id');
 
         const tasks = google.tasks({ version: 'v1', auth: authClient });
         await tasks.tasks.patch({
@@ -756,6 +759,7 @@ app.on('ready', () => {
     safeHandle('update-task', async (event, { taskListId, taskId, updates }) => {
         if (!authClient) authClient = await loadSavedCredentialsIfExist();
         if (!authClient) throw new Error('Not authenticated');
+        if (!isValidGoogleId(taskListId) || !isValidGoogleId(taskId)) throw new Error('Invalid task id');
 
         const tasks = google.tasks({ version: 'v1', auth: authClient });
         const res = await tasks.tasks.patch({
@@ -770,6 +774,7 @@ app.on('ready', () => {
     safeHandle('delete-task', async (event, { taskListId, taskId }) => {
         if (!authClient) authClient = await loadSavedCredentialsIfExist();
         if (!authClient) throw new Error('Not authenticated');
+        if (!isValidGoogleId(taskListId) || !isValidGoogleId(taskId)) throw new Error('Invalid task id');
 
         const tasks = google.tasks({ version: 'v1', auth: authClient });
         await tasks.tasks.delete({ tasklist: taskListId, task: taskId });

--- a/dashboard/electron/oauth-callback.js
+++ b/dashboard/electron/oauth-callback.js
@@ -1,0 +1,44 @@
+const { URL } = require('url');
+
+/**
+ * Validate the OAuth loopback callback request URL.
+ *
+ * Returns { ok: true, code } when the callback is a legitimate response to the
+ * request we initiated, or { ok: false, error } otherwise. Checks, in order:
+ *  - the URL parses and the path is EXACTLY /oauth2callback (not a substring,
+ *    which the old `indexOf('/oauth2callback') > -1` check allowed);
+ *  - no OAuth `error` param;
+ *  - the `state` param matches the one we generated (CSRF protection);
+ *  - an authorization `code` is present.
+ *
+ * @param {string} reqUrl - raw req.url from the loopback server
+ * @param {string} expectedState - the state we sent in generateAuthUrl
+ * @param {number} port - loopback port (URL base)
+ */
+function parseOAuthCallback(reqUrl, expectedState, port) {
+    let u;
+    try {
+        u = new URL(reqUrl, `http://localhost:${port}`);
+    } catch {
+        return { ok: false, error: 'Malformed callback URL' };
+    }
+    if (u.pathname !== '/oauth2callback') {
+        return { ok: false, error: 'Unexpected callback path' };
+    }
+    const params = u.searchParams;
+    const oauthErr = params.get('error');
+    if (oauthErr) {
+        return { ok: false, error: `OAuth error: ${oauthErr}` };
+    }
+    const state = params.get('state');
+    if (!expectedState || !state || state !== expectedState) {
+        return { ok: false, error: 'OAuth state mismatch (possible CSRF)' };
+    }
+    const code = params.get('code');
+    if (!code) {
+        return { ok: false, error: 'Missing authorization code' };
+    }
+    return { ok: true, code };
+}
+
+module.exports = { parseOAuthCallback };

--- a/dashboard/electron/recurrence-manager.js
+++ b/dashboard/electron/recurrence-manager.js
@@ -10,6 +10,9 @@ const { RRule } = require('rrule');
 const configManager = require('./config-manager');
 const log = require('./logger');
 
+// DoS / correctness bound for stored RRULE strings.
+const MAX_RRULE_LEN = 2048;
+
 class RecurrenceManager {
     constructor() {
         this.rules = [];
@@ -64,6 +67,9 @@ class RecurrenceManager {
      * @returns {Object} Created rule
      */
     createRule({ title, notes, rruleString, taskListId }) {
+        if (!this.isValidRRule(rruleString)) {
+            throw new Error('Invalid recurrence rule');
+        }
         const rule = {
             id: this.generateId(),
             title,
@@ -88,6 +94,10 @@ class RecurrenceManager {
     updateRule(id, updates) {
         const index = this.rules.findIndex(r => r.id === id);
         if (index === -1) return null;
+
+        if (updates.rrule !== undefined && !this.isValidRRule(updates.rrule)) {
+            throw new Error('Invalid recurrence rule');
+        }
 
         // If rrule changed, recalculate next due
         if (updates.rrule && updates.rrule !== this.rules[index].rrule) {
@@ -163,6 +173,23 @@ class RecurrenceManager {
         } catch (e) {
             log.error('[RecurrenceManager] Invalid RRULE:', rruleString, e);
             return null;
+        }
+    }
+
+    /**
+     * Validate an RRULE string before storing/parsing it (DoS + correctness guard).
+     * @param {string} rruleString
+     * @returns {boolean}
+     */
+    isValidRRule(rruleString) {
+        if (typeof rruleString !== 'string' || rruleString.length === 0 || rruleString.length > MAX_RRULE_LEN) {
+            return false;
+        }
+        try {
+            RRule.fromString(rruleString);
+            return true;
+        } catch {
+            return false;
         }
     }
 

--- a/dashboard/electron/url-trust.js
+++ b/dashboard/electron/url-trust.js
@@ -1,0 +1,46 @@
+const { URL } = require('url');
+
+// Google domains trusted for navigation / content loading.
+const TRUSTED_DOMAINS = [
+    'accounts.google.com',
+    'docs.google.com',
+    'drive.google.com',
+    'meet.google.com',
+    'sheets.google.com',
+    'slides.google.com',
+    'calendar.google.com',
+    'mail.google.com',
+    'myaccount.google.com',
+    'tasks.google.com'
+];
+
+/**
+ * Is `urlString` a trusted navigation/content destination?
+ *  - file:// (production bundle) -> trusted
+ *  - localhost -> trusted ONLY on the exact dev-server port (not any localhost port)
+ *  - https Google domains (and their subdomains) -> trusted
+ *  - everything else -> not trusted
+ *
+ * @param {string} urlString
+ * @param {object} [opts]
+ * @param {number} [opts.vitePort] - dev-server port; localhost is trusted only here
+ * @param {string[]} [opts.trustedDomains]
+ */
+function isTrustedURL(urlString, { vitePort, trustedDomains = TRUSTED_DOMAINS } = {}) {
+    try {
+        const parsed = new URL(urlString);
+        if (parsed.protocol === 'file:') return true;
+        if (parsed.hostname === 'localhost') {
+            // Pin to the dev server's exact port (was: any localhost port).
+            return vitePort != null && parsed.port === String(vitePort);
+        }
+        if (parsed.protocol !== 'https:') return false;
+        return trustedDomains.some(domain =>
+            parsed.hostname === domain || parsed.hostname.endsWith('.' + domain)
+        );
+    } catch {
+        return false;
+    }
+}
+
+module.exports = { isTrustedURL, TRUSTED_DOMAINS };

--- a/dashboard/electron/validators.js
+++ b/dashboard/electron/validators.js
@@ -1,0 +1,16 @@
+/**
+ * Shared input validators for IPC boundaries. Pure functions, no Electron deps,
+ * so they are trivially unit-testable and reusable across handlers.
+ */
+
+// Google Tasks list/task IDs are URL-safe token strings. Reject anything with
+// path separators, whitespace, or other unexpected characters before it is
+// passed to the Google API (defence against injection / malformed requests).
+function isValidGoogleId(id) {
+    return typeof id === 'string'
+        && id.length > 0
+        && id.length <= 256
+        && /^[A-Za-z0-9_-]+$/.test(id);
+}
+
+module.exports = { isValidGoogleId };

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -92,13 +92,13 @@
             "license": "ISC"
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -107,9 +107,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -117,21 +117,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -158,14 +158,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -175,14 +175,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -202,9 +202,9 @@
             }
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -212,29 +212,29 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -254,9 +254,9 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -264,9 +264,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -274,9 +274,9 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -284,27 +284,27 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-            "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-            "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -355,33 +355,33 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -389,14 +389,14 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -561,9 +561,9 @@
             "license": "MIT"
         },
         "node_modules/@electron/asar/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -837,9 +837,9 @@
             "license": "MIT"
         },
         "node_modules/@electron/universal/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1414,9 +1414,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1495,9 +1495,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2658,9 +2658,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2675,9 +2672,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2692,9 +2686,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2709,9 +2700,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2726,9 +2714,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2743,9 +2728,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2760,9 +2742,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2777,9 +2756,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2794,9 +2770,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2811,9 +2784,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2828,9 +2798,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2845,9 +2812,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2862,9 +2826,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3218,9 +3179,9 @@
             }
         },
         "node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+            "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3635,9 +3596,9 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.11",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-            "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+            "version": "0.8.13",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+            "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4314,9 +4275,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-            "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+            "version": "2.10.38",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+            "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -4374,9 +4335,9 @@
             "optional": true
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4387,9 +4348,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+            "version": "4.28.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+            "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
             "dev": true,
             "funding": [
                 {
@@ -4407,11 +4368,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.9.0",
-                "caniuse-lite": "^1.0.30001759",
-                "electron-to-chromium": "^1.5.263",
-                "node-releases": "^2.0.27",
-                "update-browserslist-db": "^1.2.0"
+                "baseline-browser-mapping": "^2.10.38",
+                "caniuse-lite": "^1.0.30001799",
+                "electron-to-chromium": "^1.5.376",
+                "node-releases": "^2.0.48",
+                "update-browserslist-db": "^1.2.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -4583,9 +4544,9 @@
             "license": "MIT"
         },
         "node_modules/cacache/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4724,9 +4685,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001776",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
-            "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
+            "version": "1.0.30001799",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
             "dev": true,
             "funding": [
                 {
@@ -5063,9 +5024,9 @@
             "license": "MIT"
         },
         "node_modules/config-file-ts/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5569,9 +5530,9 @@
             "license": "MIT"
         },
         "node_modules/dir-compare/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6030,9 +5991,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.307",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-            "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+            "version": "1.5.378",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
+            "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -6487,9 +6448,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6558,9 +6519,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6731,9 +6692,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "funding": [
                 {
                     "type": "github",
@@ -6828,9 +6789,9 @@
             "license": "MIT"
         },
         "node_modules/filelist/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6882,9 +6843,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-            "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -6933,17 +6894,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -7287,9 +7248,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7421,9 +7382,9 @@
             "license": "MIT"
         },
         "node_modules/googleapis-common/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -7583,9 +7544,9 @@
             "license": "MIT"
         },
         "node_modules/googleapis/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -7870,9 +7831,9 @@
             "license": "ISC"
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -8138,9 +8099,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8710,10 +8671,20 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -9036,9 +9007,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -9527,9 +9498,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.15",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
             "dev": true,
             "funding": [
                 {
@@ -9689,11 +9660,14 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.36",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+            "version": "2.0.49",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.49.tgz",
+            "integrity": "sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/nopt": {
             "version": "6.0.0",
@@ -10203,9 +10177,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10241,9 +10215,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "dev": true,
             "funding": [
                 {
@@ -10261,7 +10235,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -10429,9 +10403,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-            "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
@@ -10546,9 +10520,9 @@
             "peer": true
         },
         "node_modules/readdir-glob/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -11813,9 +11787,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12154,9 +12128,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12573,9 +12547,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
## What this does (plain English)

The High-severity tier of the GoogolVibe security hardening - five defence-in-depth fixes on top of the Critical tier (PR #21).

**#4 - Google sign-in is now protected against request forgery (CSRF).** The sign-in used a small local web server to catch the result but did not check the result belonged to the request it started, and matched the callback address loosely. It now sends a random one-time token and only accepts a result that returns the same token, on the exact callback address, with no error.

**#5 - IDs and recurrence rules are validated before use.** Task and list IDs from the app's web layer are checked to be plain safe tokens before being sent to Google. Repeat-task rules are rejected if empty, too long, or not a real rule - so a malformed rule can't be stored or slow the app.

**#6 - The web content-security-policy is tightened (partial).** Added rules that block browser plugins, page-address hijacking, and the app being embedded elsewhere. Three further tightenings are intentionally left for a follow-up because they need the running app to verify (a dev-mode policy; removing inline-style permission, which needs a nonce for React; and a policy for the Google-pages window, which must keep Google's own policy or login breaks). Reasons are in the code.

**#7 - Out-of-date dependencies (partial).** Applied all the safe, non-breaking updates: known issues dropped from 48 to 32. The rest need major version jumps (Electron, Sentry, Google APIs) that can break the app, so they are left for a separate, carefully tested upgrade rather than a blind bump.

**#8 - Error messages no longer leak file paths or secrets to the web layer.** On failure the full detail is still logged internally, but the message handed back to the web layer is scrubbed of filesystem paths and secret-looking strings.

## Dependency - please read first

This PR is **stacked on PR #21** (Critical), which is stacked on **PR #19**. Base is `feat/security-critical`. Review/merge order: **#19 -> #21 -> this**. Once the lower ones land I will retarget and rebase. The diff shows only the High-tier changes.

## Test plan

- [x] Electron suite green - 196 tests (21 new: oauth-callback 7, validators 4, recurrence rrule 5, ipc-safety 5)
- [x] Renderer suite green - 3 tests
- [x] `npm run build` green
- [ ] Manual: Google login still works (state check); invalid task ids rejected; bad recurrence rules rejected; app UI unaffected by the new CSP directives

Deferred to follow-ups (documented in code): the three risky CSP tightenings (#6) and the breaking dependency major-upgrades (#7) - both need a running-app check. The Medium tier (#9-13) follows as a separate PR.
