### PR TITLE
fix(security): Medium tier - window options, DevTools gate, localhost trust, log redaction

### DIFF
--- a/dashboard/electron/__tests__/log-redact.test.mjs
+++ b/dashboard/electron/__tests__/log-redact.test.mjs
@@ -1,0 +1,38 @@
+/**
+ * Security regression — Medium #13 (log redaction). Secret-shaped strings must
+ * not reach log files/console. Mutation-sensitive: fails if a pattern is dropped.
+ */
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const { redactSecrets } = require('../log-redact.js')
+
+describe('redactSecrets', () => {
+  it('redacts Google access tokens (ya29.)', () => {
+    const out = redactSecrets('token=ya29.A0ARrdaM-abcDEF_123')
+    expect(out).not.toContain('ya29.A0ARrdaM')
+    expect(out).toContain('[redacted-token]')
+  })
+
+  it('redacts Google refresh tokens (1//)', () => {
+    expect(redactSecrets('refresh 1//0gabcDEF_ghi-123')).toContain('[redacted-token]')
+  })
+
+  it('redacts sk- and AIza API keys', () => {
+    expect(redactSecrets('key sk-abcdefghijklmnop1234')).toContain('[redacted-key]')
+    expect(redactSecrets('key AIzaSyAbcdefGhIjk123')).toContain('[redacted-key]')
+  })
+
+  it('redacts Bearer tokens', () => {
+    expect(redactSecrets('Authorization: Bearer abc.def-123')).toContain('Bearer [redacted]')
+  })
+
+  it('leaves ordinary log text unchanged', () => {
+    expect(redactSecrets('Calling tool: get_tasks')).toBe('Calling tool: get_tasks')
+  })
+
+  it('handles non-string input', () => {
+    expect(redactSecrets(undefined)).toBe(undefined)
+  })
+})

--- a/dashboard/electron/__tests__/url-trust.test.mjs
+++ b/dashboard/electron/__tests__/url-trust.test.mjs
@@ -1,0 +1,43 @@
+/**
+ * Security regression — Medium #11 (isTrustedURL trusted localhost on ANY port).
+ * localhost is now trusted only on the exact dev-server port. Mutation-sensitive:
+ * fails if the port pin is removed or the domain check is loosened.
+ */
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+const { isTrustedURL } = require('../url-trust.js')
+
+const VITE = 9000
+
+describe('isTrustedURL (localhost pinned to dev port)', () => {
+  it('trusts file:// (production bundle)', () => {
+    expect(isTrustedURL('file:///app/index.html', { vitePort: VITE })).toBe(true)
+  })
+
+  it('trusts localhost ONLY on the dev-server port', () => {
+    expect(isTrustedURL(`http://localhost:${VITE}/`, { vitePort: VITE })).toBe(true)
+    expect(isTrustedURL('http://localhost:1337/', { vitePort: VITE })).toBe(false)
+    expect(isTrustedURL('http://localhost/', { vitePort: VITE })).toBe(false)
+  })
+
+  it('does not trust localhost when no vitePort is supplied', () => {
+    expect(isTrustedURL(`http://localhost:${VITE}/`, {})).toBe(false)
+  })
+
+  it('trusts https Google domains and their subdomains', () => {
+    expect(isTrustedURL('https://docs.google.com/x', { vitePort: VITE })).toBe(true)
+    expect(isTrustedURL('https://foo.drive.google.com/', { vitePort: VITE })).toBe(true)
+  })
+
+  it('rejects non-https, look-alike and untrusted domains', () => {
+    expect(isTrustedURL('http://docs.google.com/', { vitePort: VITE })).toBe(false)
+    expect(isTrustedURL('https://evil.com/', { vitePort: VITE })).toBe(false)
+    expect(isTrustedURL('https://google.com.evil.com/', { vitePort: VITE })).toBe(false)
+  })
+
+  it('rejects malformed urls', () => {
+    expect(isTrustedURL('not a url', { vitePort: VITE })).toBe(false)
+  })
+})

--- a/dashboard/electron/log-redact.js
+++ b/dashboard/electron/log-redact.js
@@ -1,0 +1,15 @@
+/**
+ * Redact secret-shaped substrings from log text so tokens / API keys never reach
+ * log files or the console. Pure, no deps. Used as an electron-log hook.
+ */
+function redactSecrets(text) {
+    if (typeof text !== 'string' || text.length === 0) return text;
+    return text
+        .replace(/ya29\.[A-Za-z0-9._\-]+/g, '[redacted-token]')   // Google access tokens
+        .replace(/1\/\/[A-Za-z0-9._\-]+/g, '[redacted-token]')    // Google refresh tokens
+        .replace(/sk-[A-Za-z0-9._\-]{16,}/g, '[redacted-key]')    // sk-style API keys
+        .replace(/AIza[A-Za-z0-9._\-]{10,}/g, '[redacted-key]')   // Google API keys
+        .replace(/Bearer\s+[A-Za-z0-9._\-]+/gi, 'Bearer [redacted]');
+}
+
+module.exports = { redactSecrets };

--- a/dashboard/electron/logger.js
+++ b/dashboard/electron/logger.js
@@ -1,4 +1,5 @@
 const log = require('electron-log/main');
+const { redactSecrets } = require('./log-redact');
 
 log.initialize();
 
@@ -11,5 +12,16 @@ log.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}';
 const level = process.env.NODE_ENV === 'development' ? 'debug' : 'info';
 log.transports.file.level = level;
 log.transports.console.level = level;
+
+// Redact secret-shaped strings from every log line (defence in depth). Guarded so
+// an electron-log API change cannot break logging.
+if (Array.isArray(log.hooks)) {
+    log.hooks.push((message) => {
+        if (message && Array.isArray(message.data)) {
+            message.data = message.data.map((d) => (typeof d === 'string' ? redactSecrets(d) : d));
+        }
+        return message;
+    });
+}
 
 module.exports = log;

--- a/dashboard/electron/main.js
+++ b/dashboard/electron/main.js
@@ -18,6 +18,7 @@ const { safeHandle } = require('./ipc-safety');
 const tokenStorage = require('./token-storage');
 const { isValidGoogleId } = require('./validators');
 const { parseOAuthCallback } = require('./oauth-callback');
+const urlTrust = require('./url-trust');
 
 log.info('[Googol Vibe] App starting — log transport active');
 
@@ -46,36 +47,10 @@ let authWindow;
 let authClient;
 let contentView = null; // Track the active BrowserView
 
-// Security: Trusted domains for navigation and content loading
-const TRUSTED_DOMAINS = [
-    'accounts.google.com',
-    'docs.google.com',
-    'drive.google.com',
-    'meet.google.com',
-    'sheets.google.com',
-    'slides.google.com',
-    'calendar.google.com',
-    'mail.google.com',
-    'myaccount.google.com',
-    'tasks.google.com'
-];
-
-/**
- * Check if a URL is a trusted destination.
- * Allows Google domains, localhost (dev server), and file:// (production).
- */
+// URL trust (navigation / content loading) lives in ./url-trust (pure + tested).
+// localhost is trusted ONLY on the dev-server port, not any localhost port (#11).
 function isTrustedURL(urlString) {
-    try {
-        const parsed = new URL(urlString);
-        if (parsed.protocol === 'file:') return true;
-        if (parsed.hostname === 'localhost') return true;
-        if (parsed.protocol !== 'https:') return false;
-        return TRUSTED_DOMAINS.some(domain =>
-            parsed.hostname === domain || parsed.hostname.endsWith('.' + domain)
-        );
-    } catch {
-        return false;
-    }
+    return urlTrust.isTrustedURL(urlString, { vitePort: configManager.getVitePort() });
 }
 
 // ConfigManager provides all paths - see config-manager.js for details
@@ -174,6 +149,8 @@ function authenticateWithLoopback(oAuth2Client) {
                 webPreferences: {
                     nodeIntegration: false,
                     contextIsolation: true,
+                    sandbox: true,
+                    webSecurity: true,
                     partition: 'persist:googleos'
                 },
                 autoHideMenuBar: true,
@@ -444,6 +421,8 @@ const createWindow = () => {
             preload: path.join(__dirname, 'preload.js'),
             nodeIntegration: false,
             contextIsolation: true,
+            sandbox: true,
+            webSecurity: true,
             partition: 'persist:googolvibe'
         },
         titleBarStyle: 'hiddenInset',
@@ -486,7 +465,8 @@ const createWindow = () => {
 
     mainWindow.loadURL(startUrl);
 
-    if (isDev) {
+    // DevTools only when explicitly opted in (GV_DEVTOOLS=1), not on every dev run.
+    if (process.env.GV_DEVTOOLS === '1') {
         mainWindow.webContents.openDevTools();
     }
 
@@ -984,6 +964,8 @@ app.on('ready', () => {
             webPreferences: {
                 nodeIntegration: false,
                 contextIsolation: true,
+                sandbox: true,
+                webSecurity: true,
                 partition: 'persist:googleos'
             }
         });

--- a/dashboard/electron/url-trust.js
+++ b/dashboard/electron/url-trust.js
@@ -1,0 +1,46 @@
+const { URL } = require('url');
+
+// Google domains trusted for navigation / content loading.
+const TRUSTED_DOMAINS = [
+    'accounts.google.com',
+    'docs.google.com',
+    'drive.google.com',
+    'meet.google.com',
+    'sheets.google.com',
+    'slides.google.com',
+    'calendar.google.com',
+    'mail.google.com',
+    'myaccount.google.com',
+    'tasks.google.com'
+];
+
+/**
+ * Is `urlString` a trusted navigation/content destination?
+ *  - file:// (production bundle) -> trusted
+ *  - localhost -> trusted ONLY on the exact dev-server port (not any localhost port)
+ *  - https Google domains (and their subdomains) -> trusted
+ *  - everything else -> not trusted
+ *
+ * @param {string} urlString
+ * @param {object} [opts]
+ * @param {number} [opts.vitePort] - dev-server port; localhost is trusted only here
+ * @param {string[]} [opts.trustedDomains]
+ */
+function isTrustedURL(urlString, { vitePort, trustedDomains = TRUSTED_DOMAINS } = {}) {
+    try {
+        const parsed = new URL(urlString);
+        if (parsed.protocol === 'file:') return true;
+        if (parsed.hostname === 'localhost') {
+            // Pin to the dev server's exact port (was: any localhost port).
+            return vitePort != null && parsed.port === String(vitePort);
+        }
+        if (parsed.protocol !== 'https:') return false;
+        return trustedDomains.some(domain =>
+            parsed.hostname === domain || parsed.hostname.endsWith('.' + domain)
+        );
+    } catch {
+        return false;
+    }
+}
+
+module.exports = { isTrustedURL, TRUSTED_DOMAINS };


### PR DESCRIPTION
## What this does (plain English)

The Medium-severity tier - the final set of the GoogolVibe security hardening (after Critical PR #21 and High PR #22). Five lower-risk, defence-in-depth fixes.

**#9 - Window security options are set explicitly.** The app's windows now explicitly enable sandboxing and web-security (Electron's safe defaults; pinning them means a future edit cannot silently weaken them).

**#10 - Developer tools no longer open automatically.** They previously opened on every dev run; now only when explicitly asked for (GV_DEVTOOLS=1).

**#11 - The "trusted address" check is tighter.** The app trusted any address on localhost; it now trusts localhost only on the exact dev-server port. Moved into a small, tested module.

**#12 - already handled.** The Anthropic key's plaintext fallback (used only when the OS has no keychain) already warns and writes with restricted permissions - no change needed (low priority on Windows).

**#13 - Secrets are scrubbed from logs.** Tokens and API keys are masked before any log line reaches a file or the console. (The Critical tier already stopped logging raw AI tool input.)

## Dependency - please read first

Final PR in the stack: **#19 -> #21 (Critical) -> #22 (High) -> this**. Base is `feat/security-high`. Review/merge in that order; I will retarget/rebase as the lower ones land.

## Test plan

- [x] Electron suite green - 208 tests (12 new: url-trust 6, log-redact 6)
- [x] Renderer suite green - 3 tests
- [x] `npm run build` green
- [ ] Manual: app still launches and logs in (sandbox/webSecurity); Google links/docs still open (localhost-port trust); DevTools only with GV_DEVTOOLS=1

This completes the 13-finding hardening audit. Deferred follow-ups (documented in code, each needs a running-app check): the three risky CSP tightenings (#6) and the breaking dependency major-upgrades (#7).
